### PR TITLE
Add option to hide fields in the admin UI

### DIFF
--- a/django/cohiva/settings_defaults.py
+++ b/django/cohiva/settings_defaults.py
@@ -987,8 +987,10 @@ ROCKETCHAT_WEBHOOK_AUTORESPONDER = {
 COHIVA_REPORT_API_TOKEN = None
 COHIVA_REPORT_EMAIL = GENO_DEFAULT_EMAIL
 
-## With the following option you can change the default configuration of the Django admin site
-# for the Cohiva models (fields, fieldsets, readonly_fields, search_fields, autocomplete_fields, list_display, list_filter)
+# With the following options you can change the default configuration of the Django admin UI:
+#
+# A) Completely overwrite admin class attributes: fields, fieldsets, readonly_fields,
+#    search_fields, autocomplete_fields, list_display, or list_filter.
 # COHIVA_ADMIN_FIELDS = {
 #     "geno.admin": {
 #         "RentalUnitAdmin.fields": [
@@ -1014,6 +1016,14 @@ COHIVA_REPORT_EMAIL = GENO_DEFAULT_EMAIL
 #             "backlinks",
 #         ],
 #     },
+# }
+#
+# B) Hide single model fields in the admin UI.
+# COHIVA_HIDE_ADMIN_FIELDS = {
+#    "geno.admin": {
+#        "AddressAdmin": ["telephoneOffice2"],
+#        "MemberAdmin": ["flag_03", "flag_04", "flag_05"],
+#    }
 # }
 
 ## Share settings

--- a/django/cohiva/settings_example.py
+++ b/django/cohiva/settings_example.py
@@ -39,3 +39,42 @@ EMAIL_HOST_PASSWORD = "secret"
 
 ## Configure the cashctrl token and tenant in base_config.py
 # FINANCIAL_ACCOUNTING_DEFAULT_BACKEND = "cashctrl"
+
+# With the following options you can change the default configuration of the Django admin UI:
+#
+# A) Completely overwrite admin class attributes: fields, fieldsets, readonly_fields,
+#    search_fields, autocomplete_fields, list_display, or list_filter
+# COHIVA_ADMIN_FIELDS = {
+#     "geno.admin": {
+#         "RentalUnitAdmin.fields": [
+#             "name",
+#             ("label", "label_short"),
+#             ("rental_type", "rooms", "min_occupancy"),
+#             ("building", "floor"),
+#             ("area", "area_balcony", "area_add"),
+#             ("height", "volume"),
+#             ("rent_netto", "nk", "nk_electricity", "rent_total"),
+#             "rent_year", # activate rent per year filed
+#             ("share", "depot"),
+#             "note",
+#             "svg_polygon",
+#             "description",
+#             "status",
+#             "adit_serial",
+#             "active",
+#             "comment",
+#             "ts_created",
+#             "ts_modified",
+#             "links",
+#             "backlinks",
+#         ],
+#     },
+# }
+#
+# B) Hide single model fields in the admin UI
+# COHIVA_HIDE_ADMIN_FIELDS = {
+#    "geno.admin": {
+#        "AddressAdmin": ["telephoneOffice2"],
+#        "MemberAdmin": ["flag_03", "flag_04", "flag_05"],
+#    }
+# }

--- a/django/cohiva/settings_for_tests.py
+++ b/django/cohiva/settings_for_tests.py
@@ -109,23 +109,3 @@ GENO_QRBILL_CREDITOR = {
 
 if "importer" not in INSTALLED_APPS:
     INSTALLED_APPS += ("importer",)
-
-# Test code to overwrite admin config
-COHIVA_ADMIN_FIELDS = {
-    "geno.admin": {
-        "RentalUnitAdmin.fields": [
-            "name",
-            "label",
-            "rental_type",
-            "rooms",
-            "min_occupancy",
-            "building",
-            "floor",
-            "area",
-            "height",
-            "volume",
-            "rent_netto",
-            "rent_year",
-        ]
-    }
-}

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -192,6 +192,7 @@ class GenoBaseAdmin(ModelAdmin, ExportXlsMixin):
                     isinstance(fieldset, (list, tuple))
                     and len(fieldset) > 1
                     and isinstance(fieldset[1], dict)
+                    and "fields" in fieldset[1]
                 ):
                     filtered_fields = filter_fields(fieldset[1].get("fields", []))
                     fieldset[1]["fields"] = filtered_fields

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -217,7 +217,17 @@ class GenoBaseAdmin(ModelAdmin, ExportXlsMixin):
                     and isinstance(fieldset[1], dict)
                     and "fields" in fieldset[1]
                 ):
-                    filtered_fields = filter_func(fieldset[1].get("fields", []))
+                    filtered_fields = []
+                    for field in fieldset[1].get("fields", []):
+                        if isinstance(field, str):
+                            if filter_func([field]):
+                                filtered_fields.append(field)
+                        elif isinstance(field, (list, tuple)):
+                            filtered_subset = filter_func(list(field))
+                            if filtered_subset:
+                                filtered_fields.append(tuple(filtered_subset))
+                        else:
+                            filtered_fields.append(field)
                     fieldset[1]["fields"] = filtered_fields
 
     @classmethod

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -1,5 +1,6 @@
 import datetime
 import gettext
+from collections.abc import Callable
 
 import pycountry
 from dateutil.relativedelta import relativedelta
@@ -174,18 +175,40 @@ class GenoBaseAdmin(ModelAdmin, ExportXlsMixin):
 
         if not fields_to_remove:
             return
+
+        cls._remove_admin_fields_from_fields(filter_fields)
+        cls._remove_admin_fields_from_fieldsets(filter_fields)
+        cls._remove_admin_fields_from_attributes(
+            filter_fields, ("search_fields", "list_display", "list_filter")
+        )
+
+    @classmethod
+    def _remove_admin_fields_from_fields(cls, filter_func: Callable[[list], list]) -> None:
+        """Remove fields from the fields attribute of the class, if present.
+
+        The fields attribute is a list/tuple that contains field names or
+        field name groups (lists/tuples of strings).
+        """
         if hasattr(cls, "fields") and isinstance(cls.fields, (list, tuple)):
             filtered_fields = []
             for field in cls.fields:
-                if isinstance(field, str) and field in fields_to_remove:
+                if isinstance(field, str) and not filter_func([field]):
                     continue
                 if isinstance(field, (list, tuple)):
-                    filtered_subset = filter_fields(field)
+                    filtered_subset = filter_func(field)
                     if filtered_subset:
                         filtered_fields.append(tuple(filtered_subset))
                 else:
                     filtered_fields.append(field)
             cls.fields = filtered_fields
+
+    @classmethod
+    def _remove_admin_fields_from_fieldsets(cls, filter_func: Callable[[list], list]) -> None:
+        """Remove fields from the fieldsets attribute of the class, if present.
+
+        The fieldsets attribute is a list/tuple of fieldsets of the form
+          ( "Fieldset label", {"fields": ("field 1", "field 2")} )
+        """
         if hasattr(cls, "fieldsets") and isinstance(cls.fieldsets, (list, tuple)):
             for fieldset in cls.fieldsets:
                 if (
@@ -194,13 +217,20 @@ class GenoBaseAdmin(ModelAdmin, ExportXlsMixin):
                     and isinstance(fieldset[1], dict)
                     and "fields" in fieldset[1]
                 ):
-                    filtered_fields = filter_fields(fieldset[1].get("fields", []))
+                    filtered_fields = filter_func(fieldset[1].get("fields", []))
                     fieldset[1]["fields"] = filtered_fields
-        for attr in (
-            "search_fields",
-            "list_display",
-            "list_filter",
-        ):
+
+    @classmethod
+    def _remove_admin_fields_from_attributes(
+        cls, filter_func: Callable[[list], list], attributes: tuple[str, ...]
+    ) -> None:
+        """
+        Remove fields from the attributes listed in the attributes parameter, if present.
+
+        The attribute must be a list/tuple of field names or lists/tuples with the field name
+        as the first element.
+        """
+        for attr in attributes:
             fields = getattr(cls, attr, [])
             if isinstance(fields, (list, tuple)):
                 filtered_fields = []
@@ -214,7 +244,7 @@ class GenoBaseAdmin(ModelAdmin, ExportXlsMixin):
                         and isinstance(field[0], str)
                     ):
                         field_name = field[0]
-                    if field_name and field_name in fields_to_remove:
+                    if field_name and not filter_func([field_name]):
                         continue
                     filtered_fields.append(field)
                 setattr(cls, attr, filtered_fields)

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -148,7 +148,7 @@ class GenoBaseAdmin(ModelAdmin, ExportXlsMixin):
             )
 
     @classmethod
-    def _overwrite_admin_config(cls, config):
+    def _overwrite_admin_config(cls, config: dict[str, list | tuple]) -> None:
         for attr in (
             "fields",
             "fieldsets",
@@ -163,8 +163,8 @@ class GenoBaseAdmin(ModelAdmin, ExportXlsMixin):
                 setattr(cls, attr, config[setting_name])
 
     @classmethod
-    def _remove_admin_fields(cls, fields_to_remove):
-        def filter_fields(field_list):
+    def _remove_admin_fields(cls, fields_to_remove: list[str]) -> None:
+        def filter_fields(field_list: list) -> list:
             filtered_list = []
             for f in field_list:
                 if isinstance(f, str) and f in fields_to_remove:

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -131,25 +131,92 @@ class GenoBaseAdmin(ModelAdmin, ExportXlsMixin):
 
     def __init__(self, model, admin_site):
         super().__init__(model, admin_site)
-        ## Load custom admin config
         module_name = self.__module__
+        class_name = type(self).__name__
+        ## Apply custom admin config
         if (
             hasattr(settings, "COHIVA_ADMIN_FIELDS")
             and module_name in settings.COHIVA_ADMIN_FIELDS
         ):
-            class_name = type(self).__name__
-            for attr in (
-                "fields",
-                "fieldsets",
-                "readonly_fields",
-                "search_fields",
-                "autocomplete_fields",
-                "list_display",
-                "list_filter",
-            ):
-                setting_name = f"{class_name}.{attr}"
-                if setting_name in settings.COHIVA_ADMIN_FIELDS[module_name]:
-                    setattr(self, attr, settings.COHIVA_ADMIN_FIELDS[module_name][setting_name])
+            self._overwrite_admin_config(settings.COHIVA_ADMIN_FIELDS.get(module_name))
+        if (
+            hasattr(settings, "COHIVA_HIDE_ADMIN_FIELDS")
+            and module_name in settings.COHIVA_HIDE_ADMIN_FIELDS
+        ):
+            self._remove_admin_fields(
+                settings.COHIVA_HIDE_ADMIN_FIELDS.get(module_name).get(class_name, [])
+            )
+
+    @classmethod
+    def _overwrite_admin_config(cls, config):
+        for attr in (
+            "fields",
+            "fieldsets",
+            "readonly_fields",
+            "search_fields",
+            "autocomplete_fields",
+            "list_display",
+            "list_filter",
+        ):
+            setting_name = f"{cls.__name__}.{attr}"
+            if setting_name in config:
+                setattr(cls, attr, config[setting_name])
+
+    @classmethod
+    def _remove_admin_fields(cls, fields_to_remove):
+        def filter_fields(field_list):
+            filtered_list = []
+            for f in field_list:
+                if isinstance(f, str) and f in fields_to_remove:
+                    continue
+                filtered_list.append(f)
+            return filtered_list
+
+        if not fields_to_remove:
+            return
+        if hasattr(cls, "fields") and isinstance(cls.fields, (list, tuple)):
+            filtered_fields = []
+            for field in cls.fields:
+                if isinstance(field, str) and field in fields_to_remove:
+                    continue
+                if isinstance(field, (list, tuple)):
+                    filtered_subset = filter_fields(field)
+                    if filtered_subset:
+                        filtered_fields.append(tuple(filtered_subset))
+                else:
+                    filtered_fields.append(field)
+            cls.fields = filtered_fields
+        if hasattr(cls, "fieldsets") and isinstance(cls.fieldsets, (list, tuple)):
+            for fieldset in cls.fieldsets:
+                if (
+                    isinstance(fieldset, (list, tuple))
+                    and len(fieldset) > 1
+                    and isinstance(fieldset[1], dict)
+                ):
+                    filtered_fields = filter_fields(fieldset[1].get("fields", []))
+                    fieldset[1]["fields"] = filtered_fields
+        for attr in (
+            "search_fields",
+            "list_display",
+            "list_filter",
+        ):
+            fields = getattr(cls, attr, [])
+            if isinstance(fields, (list, tuple)):
+                filtered_fields = []
+                for field in getattr(cls, attr):
+                    field_name = None
+                    if isinstance(field, str):
+                        field_name = field
+                    elif (
+                        isinstance(field, (list, tuple))
+                        and len(field)
+                        and isinstance(field[0], str)
+                    ):
+                        field_name = field[0]
+                    if field_name and field_name in fields_to_remove:
+                        continue
+                    filtered_fields.append(field)
+                setattr(cls, attr, filtered_fields)
 
 
 @admin.display(description="Anrede auf 'Herr' setzen")

--- a/django/geno/tests/test_admin.py
+++ b/django/geno/tests/test_admin.py
@@ -347,12 +347,12 @@ class GenoAdminTest(GenoAdminTestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_admin_fields_config_overwrite(self):
-        old_setting = getattr(settings, "COHIVA_ADMIN_FIELDS", None)
-        old_address_fields = admin.AddressAdmin.fields
+        old_setting = getattr(settings, "COHIVA_ADMIN_FIELDS", {})
+        old_address_fields = admin.AddressAdmin.fields.copy()
         new_address_fields = ["test1", ("test2a", "test2b"), "test3"]
-        old_list_filter = admin.AddressAdmin.list_filter
+        old_list_filter = admin.AddressAdmin.list_filter.copy()
         new_list_filter = ["test_filter"]
-        old_reservation_fields = ReservationAdmin.fields
+        old_reservation_fields = ReservationAdmin.fields.copy()
         new_reservation_fields = ["test_reservation"]
         settings.COHIVA_ADMIN_FIELDS = {
             "geno.admin": {
@@ -369,23 +369,33 @@ class GenoAdminTest(GenoAdminTestCase):
         self.assertEqual(admin.AddressAdmin.list_filter, new_list_filter)
         self.assertEqual(ReservationAdmin.fields, new_reservation_fields)
         # Restore state
-        if old_setting:
-            settings.COHIVA_ADMIN_FIELDS = old_setting
+        settings.COHIVA_ADMIN_FIELDS = old_setting
         admin.AddressAdmin.fields = old_address_fields
         admin.AddressAdmin.list_filter = old_list_filter
         ReservationAdmin.fields = old_reservation_fields
 
     def test_admin_fields_config_hide_fields(self):
         self.assertIn("organization", admin.AddressAdmin.fields)
-        old_setting = getattr(settings, "COHIVA_HIDE_ADMIN_FIELDS", None)
+        old_setting = getattr(settings, "COHIVA_HIDE_ADMIN_FIELDS", {})
         settings.COHIVA_HIDE_ADMIN_FIELDS = {"geno.admin": {"AddressAdmin": ["organization"]}}
-        old_address_fields = admin.AddressAdmin.fields
+        old_address_fields = admin.AddressAdmin.fields.copy()
+        old_address_fieldsets = (
+            admin.AddressAdmin.fieldsets.copy()
+            if isinstance(admin.AddressAdmin.fieldsets, list)
+            else admin.AddressAdmin.fieldsets
+        )
+        old_search_fields = admin.AddressAdmin.search_fields.copy()
+        old_list_display = admin.AddressAdmin.list_display.copy()
+        old_list_filter = admin.AddressAdmin.list_filter.copy()
         admin.AddressAdmin(model=Address, admin_site=django_admin.site)
         self.assertNotIn("organization", admin.AddressAdmin.fields)
         # Restore state
-        if old_setting:
-            settings.COHIVA_HIDE_ADMIN_FIELDS = old_setting
+        settings.COHIVA_HIDE_ADMIN_FIELDS = old_setting
         admin.AddressAdmin.fields = old_address_fields
+        admin.AddressAdmin.fieldsets = old_address_fieldsets
+        admin.AddressAdmin.search_fields = old_search_fields
+        admin.AddressAdmin.list_display = old_list_display
+        admin.AddressAdmin.list_filter = old_list_filter
 
     def test_remove_admin_fields(self):
         class DummyAdmin(admin.GenoBaseAdmin):
@@ -408,6 +418,10 @@ class GenoAdminTest(GenoAdminTestCase):
             fieldsets = [
                 "keep",
                 ("name", {"fields": ["keep1", "remove1", "keep2", "remove2"]}),
+                (
+                    "name with tuple",
+                    {"fields": ["keep1", "remove1", ("keep2", "remove2", "keep3")]},
+                ),
                 ("keep-single",),
                 ["keep_something_else", {"notfields": ["remove2"]}],
                 ("keep-non-dict", "remove2"),
@@ -420,6 +434,7 @@ class GenoAdminTest(GenoAdminTestCase):
             filtered_fieldsets = [
                 "keep",
                 ("name", {"fields": ["keep1", "keep2"]}),
+                ("name with tuple", {"fields": ["keep1", ("keep2", "keep3")]}),
                 ("keep-single",),
                 ["keep_something_else", {"notfields": ["remove2"]}],
                 ("keep-non-dict", "remove2"),

--- a/django/geno/tests/test_admin.py
+++ b/django/geno/tests/test_admin.py
@@ -1,18 +1,19 @@
 import datetime
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib import admin as django_admin
 from django.db.models import Q
 from django.test import RequestFactory
 
-import geno.admin
 import geno.tests.data as geno_testdata
 from geno import admin
-from geno.admin import BooleanFieldDefaultTrueListFilter, CountryFilter
 
 # from django.conf import settings
 from geno.models import Address, Child, ContentTemplate, Contract, GenericAttribute, Member
 from geno.tests.base import MockDate
+from reservation.admin import ReservationAdmin
+from reservation.models import Reservation
 
 from .base import GenoAdminTestCase
 
@@ -232,17 +233,17 @@ class GenoAdminTest(GenoAdminTestCase):
         if model_name == "address":
             model = Address
             field_path = "active"
-            model_admin = geno.admin.AddressAdmin
+            model_admin = admin.AddressAdmin
         elif model_name == "child":
             model = Child
             field_path = "name__active"
-            model_admin = geno.admin.ChildAdmin
+            model_admin = admin.ChildAdmin
         else:
             raise ValueError("Unknown model_name")
         factory = RequestFactory()
         request = factory.get(f"/admin/geno/{model_name}/", query_params=query_params)
         admin_instance = model_admin(model, django_admin.site)
-        _filter = BooleanFieldDefaultTrueListFilter(
+        _filter = admin.BooleanFieldDefaultTrueListFilter(
             field=Address._meta.get_field("active"),
             request=request,
             params=query_params or {},
@@ -345,6 +346,142 @@ class GenoAdminTest(GenoAdminTestCase):
         response = self.client.get("/admin/geno/address/add/")
         self.assertEqual(response.status_code, 200)
 
+    def test_admin_fields_config_overwrite(self):
+        old_setting = getattr(settings, "COHIVA_ADMIN_FIELDS", None)
+        old_address_fields = admin.AddressAdmin.fields
+        new_address_fields = ["test1", ("test2a", "test2b"), "test3"]
+        old_list_filter = admin.AddressAdmin.list_filter
+        new_list_filter = ["test_filter"]
+        old_reservation_fields = ReservationAdmin.fields
+        new_reservation_fields = ["test_reservation"]
+        settings.COHIVA_ADMIN_FIELDS = {
+            "geno.admin": {
+                "AddressAdmin.fields": new_address_fields,
+                "AddressAdmin.list_filter": new_list_filter,
+            },
+            "reservation.admin": {
+                "ReservationAdmin.fields": new_reservation_fields,
+            },
+        }
+        admin.AddressAdmin(model=Address, admin_site=django_admin.site)
+        ReservationAdmin(model=Reservation, admin_site=django_admin.site)
+        self.assertEqual(admin.AddressAdmin.fields, new_address_fields)
+        self.assertEqual(admin.AddressAdmin.list_filter, new_list_filter)
+        self.assertEqual(ReservationAdmin.fields, new_reservation_fields)
+        # Restore state
+        if old_setting:
+            settings.COHIVA_ADMIN_FIELDS = old_setting
+        admin.AddressAdmin.fields = old_address_fields
+        admin.AddressAdmin.list_filter = old_list_filter
+        ReservationAdmin.fields = old_reservation_fields
+
+    def test_admin_fields_config_hide_fields(self):
+        self.assertIn("organization", admin.AddressAdmin.fields)
+        old_setting = getattr(settings, "COHIVA_HIDE_ADMIN_FIELDS", None)
+        settings.COHIVA_HIDE_ADMIN_FIELDS = {"geno.admin": {"AddressAdmin": ["organization"]}}
+        old_address_fields = admin.AddressAdmin.fields
+        admin.AddressAdmin(model=Address, admin_site=django_admin.site)
+        self.assertNotIn("organization", admin.AddressAdmin.fields)
+        # Restore state
+        if old_setting:
+            settings.COHIVA_HIDE_ADMIN_FIELDS = old_setting
+        admin.AddressAdmin.fields = old_address_fields
+
+    def test_remove_admin_fields(self):
+        class DummyAdmin(admin.GenoBaseAdmin):
+            fields = (
+                "keep1",
+                "remove1",
+                ("tuple-keep1", "tuple-remove1"),
+                ["list-remove2", "list-keep2", "list-remove3", "list-keep3"],
+                "keep2",
+                "remove2",
+                None,
+            )
+            filtered_fields = [
+                "keep1",
+                ("tuple-keep1",),
+                ("list-keep2", "list-keep3"),
+                "keep2",
+                None,
+            ]
+            fieldsets = [
+                "keep",
+                ("name", {"fields": ["keep1", "remove1", "keep2", "remove2"]}),
+                ("keep-single",),
+                ["keep_something_else", {"notfields": ["remove2"]}],
+                ("keep-non-dict", "remove2"),
+                (
+                    "remove-with-other",
+                    {"fields": ["remove2"], "other1": ["remove2"]},
+                    {"fields": ["remove1"]},
+                ),
+            ]
+            filtered_fieldsets = [
+                "keep",
+                ("name", {"fields": ["keep1", "keep2"]}),
+                ("keep-single",),
+                ["keep_something_else", {"notfields": ["remove2"]}],
+                ("keep-non-dict", "remove2"),
+                (
+                    "remove-with-other",
+                    {"fields": [], "other1": ["remove2"]},
+                    {"fields": ["remove1"]},
+                ),
+            ]
+            search_fields = [
+                "keep1",
+                "remove1",
+                ("tuple-keep1", "tuple-remove1"),
+                ("tuple-remove1", "tuple-keep1"),
+                ("remove2",),
+                (None, "keep-this"),
+                "keep2",
+                None,
+            ]
+            filtered_search_fields = [
+                "keep1",
+                ("tuple-keep1", "tuple-remove1"),
+                (None, "keep-this"),
+                "keep2",
+                None,
+            ]
+            list_display = (
+                "keep1",
+                "remove1",
+                ["tuple-keep1", "tuple-remove1"],
+                ["tuple-remove1", "tuple-keep1"],
+                ["remove2"],
+                [None, "keep-this"],
+                "keep2",
+                None,
+            )
+            filtered_list_display = [
+                "keep1",
+                ["tuple-keep1", "tuple-remove1"],
+                [None, "keep-this"],
+                "keep2",
+                None,
+            ]
+            list_filter = ["keep1"]
+
+        DummyAdmin._remove_admin_fields(
+            [
+                "remove1",
+                "remove2",
+                "tuple-remove1",
+                "tuple-remove2",
+                "list-remove1",
+                "list-remove2",
+                "list-remove3",
+            ]
+        )
+        self.assertEqual(DummyAdmin.fields, DummyAdmin.filtered_fields)
+        self.assertEqual(DummyAdmin.fieldsets, DummyAdmin.filtered_fieldsets)
+        self.assertEqual(DummyAdmin.search_fields, DummyAdmin.filtered_search_fields)
+        self.assertEqual(DummyAdmin.list_display, DummyAdmin.filtered_list_display)
+        self.assertEqual(DummyAdmin.list_filter, ["keep1"])
+
     def test_used_country_filter_lookups(self):
         Address.objects.create(name="Schweiz", country="CH")
         Address.objects.create(name="Deutschland", country="DE")
@@ -353,12 +490,12 @@ class GenoAdminTest(GenoAdminTestCase):
 
         factory = RequestFactory()
         request = factory.get("/admin/geno/address/")
-        model_admin = geno.admin.AddressAdmin(Address, django_admin.site)
+        model_admin = admin.AddressAdmin(Address, django_admin.site)
 
         with self.settings(
             GENO_ORG_INFO={"country": "Schweiz"}
         ):  # To ensure that our home country is Switzerland for tests
-            country_filter = CountryFilter(
+            country_filter = admin.CountryFilter(
                 request=request, params={}, model=Address, model_admin=model_admin
             )
             lookups = country_filter.lookups(request=request, model_admin=model_admin)


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for hiding specific model fields in the Django admin UI via configurable settings.
  * Improved admin field customization so overwrites and removals apply consistently across fields, fieldsets, search, display, and filtering.

* **Documentation**
  * Updated default and example settings comments with clearer guidance and new admin customization examples.

* **Tests**
  * Refined test setup and expanded admin configuration coverage to validate overwrite and hide behaviors (including nested structures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->