### PR TITLE
feat: add country filter to fix having all countries listed

### DIFF
--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -1,5 +1,7 @@
 import datetime
+import gettext
 
+import pycountry
 from dateutil.relativedelta import relativedelta
 from django import forms
 from django.conf import settings
@@ -19,6 +21,7 @@ from unfold.enums import ActionVariant
 from unfold.forms import AdminPasswordChangeForm, UserChangeForm, UserCreationForm
 
 import geno.settings as geno_settings
+from cohiva.utils.countries import normalize_country_code
 from geno.exporter import ExportXlsMixin
 from geno.models import (
     Address,
@@ -159,6 +162,61 @@ def set_title_mrs(modeladmin, request, queryset):
     queryset.update(title="Frau")
 
 
+class UsedCountryFilter(admin.SimpleListFilter):
+    parameter_name = "country"
+
+    def __init__(self, request, params, model, model_admin):
+        self.title = model._meta.get_field("country").verbose_name
+        self.de_trans = gettext.translation("iso3166-1", pycountry.LOCALES_DIR, languages=["de"])
+        raw_home_country = settings.GENO_ORG_INFO.get("country", "")
+        self.home_code = normalize_country_code(raw_home_country)
+        super().__init__(request, params, model, model_admin)
+
+    def get_country_name(self, code):
+        if not code:
+            return ""
+        clean_code = str(code).strip().upper()
+        country = pycountry.countries.get(alpha_2=clean_code)
+
+        return self.de_trans.gettext(country.name) if country else code
+
+    def lookups(self, request, model_admin):
+        options = []
+
+        if self.home_code:
+            home_name = self.get_country_name(self.home_code)
+            options.append((self.home_code, home_name))
+            options.append(("NOT_HOME", f"Nicht {home_name}"))
+
+        used_countries = (
+            model_admin.model.objects.exclude(country__isnull=True)
+            .exclude(country__exact="")
+            .values_list("country", flat=True)
+            .distinct()
+            .order_by("country")
+        )
+
+        options.extend(
+            [
+                (code, self.get_country_name(code))
+                for code in used_countries
+                if code != self.home_code
+            ]
+        )
+
+        return options
+
+    def queryset(self, request, queryset):
+        value = self.value()
+
+        if value == "NOT_HOME" and self.home_code:
+            return queryset.exclude(country=self.home_code)
+        elif value:
+            return queryset.filter(country=value)
+
+        return queryset
+
+
 @admin.register(Address)
 class AddressAdmin(GenoBaseAdmin):
     model = Address
@@ -223,7 +281,7 @@ class AddressAdmin(GenoBaseAdmin):
         "ignore_in_lists",
         "login_permission",
         "po_box",
-        "country",
+        UsedCountryFilter,
         "ts_created",
         "ts_modified",
     ]

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -162,31 +162,31 @@ def set_title_mrs(modeladmin, request, queryset):
     queryset.update(title="Frau")
 
 
-class UsedCountryFilter(admin.SimpleListFilter):
+class CountryFilter(admin.SimpleListFilter):
     parameter_name = "country"
 
     def __init__(self, request, params, model, model_admin):
         self.title = model._meta.get_field("country").verbose_name
         self.de_trans = gettext.translation("iso3166-1", pycountry.LOCALES_DIR, languages=["de"])
-        raw_home_country = settings.GENO_ORG_INFO.get("country", "")
-        self.home_code = normalize_country_code(raw_home_country)
+        org_country = settings.GENO_ORG_INFO.get("country", "")
+        self.org_country_code = normalize_country_code(org_country)
         super().__init__(request, params, model, model_admin)
 
-    def get_country_name(self, code):
-        if not code:
+    def get_country_name(self, country_code):
+        if not country_code:
             return ""
-        clean_code = str(code).strip().upper()
-        country = pycountry.countries.get(alpha_2=clean_code)
-
-        return self.de_trans.gettext(country.name) if country else code
+        iso_country_code = str(country_code).strip().upper()
+        # Get a country name when the country code is ISO-compliant
+        country = pycountry.countries.get(alpha_2=iso_country_code)
+        return self.de_trans.gettext(country.name) if country else country_code
 
     def lookups(self, request, model_admin):
         options = []
 
-        if self.home_code:
-            home_name = self.get_country_name(self.home_code)
-            options.append((self.home_code, home_name))
-            options.append(("NOT_HOME", f"Nicht {home_name}"))
+        if self.org_country_code:
+            org_country_name = self.get_country_name(self.org_country_code)
+            options.append((self.org_country_code, org_country_name))
+            options.append(("NOT_ORG_COUNTRY", f"Nicht {org_country_name}"))
 
         used_countries = (
             model_admin.model.objects.exclude(country__isnull=True)
@@ -200,7 +200,7 @@ class UsedCountryFilter(admin.SimpleListFilter):
             [
                 (code, self.get_country_name(code))
                 for code in used_countries
-                if code != self.home_code
+                if code != self.org_country_code
             ]
         )
 
@@ -209,8 +209,8 @@ class UsedCountryFilter(admin.SimpleListFilter):
     def queryset(self, request, queryset):
         value = self.value()
 
-        if value == "NOT_HOME" and self.home_code:
-            return queryset.exclude(country=self.home_code)
+        if value == "NOT_ORG_COUNTRY" and self.org_country_code:
+            return queryset.exclude(country=self.org_country_code)
         elif value:
             return queryset.filter(country=value)
 
@@ -281,7 +281,7 @@ class AddressAdmin(GenoBaseAdmin):
         "ignore_in_lists",
         "login_permission",
         "po_box",
-        UsedCountryFilter,
+        CountryFilter,
         "ts_created",
         "ts_modified",
     ]

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -196,13 +196,13 @@ class CountryFilter(admin.SimpleListFilter):
             .order_by("country")
         )
 
-        options.extend(
-            [
-                (code, self.get_country_name(code))
-                for code in used_countries
-                if code != self.org_country_code
-            ]
-        )
+        remaining_countries = [
+            (code, self.get_country_name(code))
+            for code in used_countries
+            if code != self.org_country_code
+        ]
+        remaining_countries.sort(key=lambda item: item[1])
+        options.extend(remaining_countries)
 
         return options
 

--- a/django/geno/tests/test_admin.py
+++ b/django/geno/tests/test_admin.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 import geno.admin
 import geno.tests.data as geno_testdata
 from geno import admin
-from geno.admin import BooleanFieldDefaultTrueListFilter
+from geno.admin import BooleanFieldDefaultTrueListFilter, UsedCountryFilter
 
 # from django.conf import settings
 from geno.models import Address, Child, ContentTemplate, Contract, GenericAttribute, Member
@@ -344,3 +344,41 @@ class GenoAdminTest(GenoAdminTestCase):
         # Bug COHIV-133 will result in a HTTP Error 500 here:
         response = self.client.get("/admin/geno/address/add/")
         self.assertEqual(response.status_code, 200)
+
+    def test_used_country_filter_lookups(self):
+        Address.objects.create(name="Schweiz", country="CH")
+        Address.objects.create(name="Deutschland", country="DE")
+        Address.objects.create(name="Spanien", country="ES")
+        Address.objects.create(name="Leer", country="")
+
+        factory = RequestFactory()
+        request = factory.get("/admin/geno/address/")
+        model_admin = geno.admin.AddressAdmin(Address, django_admin.site)
+
+        with self.settings(
+            GENO_ORG_INFO={"country": "Schweiz"}
+        ):  # To ensure that our home country is Switzerland for tests
+            country_filter = UsedCountryFilter(
+                request=request, params={}, model=Address, model_admin=model_admin
+            )
+            lookups = country_filter.lookups(request=request, model_admin=model_admin)
+
+        codes = [item[0] for item in lookups]
+
+        self.assertIn("CH", codes)
+        self.assertIn("NOT_HOME", codes)
+        self.assertIn("DE", codes)
+        self.assertIn("ES", codes)
+        self.assertNotIn("", codes)
+
+        self.assertEqual(lookups[0][0], "CH")
+        self.assertEqual(lookups[0][1], "Schweiz")
+
+        self.assertEqual(lookups[1][0], "NOT_HOME")
+        self.assertEqual(lookups[1][1], "Nicht Schweiz")
+
+        de_tuple = next(item for item in lookups if item[0] == "DE")
+        self.assertEqual(de_tuple[1], "Deutschland")
+
+        es_tuple = next(item for item in lookups if item[0] == "ES")
+        self.assertEqual(es_tuple[1], "Spanien")

--- a/django/geno/tests/test_admin.py
+++ b/django/geno/tests/test_admin.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 import geno.admin
 import geno.tests.data as geno_testdata
 from geno import admin
-from geno.admin import BooleanFieldDefaultTrueListFilter, UsedCountryFilter
+from geno.admin import BooleanFieldDefaultTrueListFilter, CountryFilter
 
 # from django.conf import settings
 from geno.models import Address, Child, ContentTemplate, Contract, GenericAttribute, Member
@@ -358,7 +358,7 @@ class GenoAdminTest(GenoAdminTestCase):
         with self.settings(
             GENO_ORG_INFO={"country": "Schweiz"}
         ):  # To ensure that our home country is Switzerland for tests
-            country_filter = UsedCountryFilter(
+            country_filter = CountryFilter(
                 request=request, params={}, model=Address, model_admin=model_admin
             )
             lookups = country_filter.lookups(request=request, model_admin=model_admin)
@@ -366,7 +366,7 @@ class GenoAdminTest(GenoAdminTestCase):
         codes = [item[0] for item in lookups]
 
         self.assertIn("CH", codes)
-        self.assertIn("NOT_HOME", codes)
+        self.assertIn("NOT_ORG_COUNTRY", codes)
         self.assertIn("DE", codes)
         self.assertIn("ES", codes)
         self.assertNotIn("", codes)
@@ -374,7 +374,7 @@ class GenoAdminTest(GenoAdminTestCase):
         self.assertEqual(lookups[0][0], "CH")
         self.assertEqual(lookups[0][1], "Schweiz")
 
-        self.assertEqual(lookups[1][0], "NOT_HOME")
+        self.assertEqual(lookups[1][0], "NOT_ORG_COUNTRY")
         self.assertEqual(lookups[1][1], "Nicht Schweiz")
 
         de_tuple = next(item for item in lookups if item[0] == "DE")


### PR DESCRIPTION
### Description
This PR resolves the issue with having all countries in the list to filter. It now shows only the ones that are used, and also adds the home country and not in home country options first.

### Changes Made
* **Unified Country Mapping:** The filter now normalizes whatever is defined in `settings.GENO_ORG_INFO` into a strict `alpha_2` code before querying the database, eliminating duplicate entries caused by config/DB mismatches.
* **Native German Translations:** Implemented `pycountry`'s internal `gettext` catalogs (`iso3166-1`) to natively translate country names to German, replacing the English defaults.

### Testing
* Tested locally using the `./develop.sh` environment.
* Verified that the primary organization country stays at the top of the list, followed by "Not in [Country]", and the rest of the database countries follow alphabetically in German.
* Passed `./scripts/before-pr.sh` successfully.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a country-based filter to the Admin address list.
  * The filter shows the organization’s country, an option to display addresses from other countries, and an “all items” view.
  * Country names are displayed in German when available, with fallbacks when not.

* **Tests**
  * Added automated coverage verifying the filter lookup values, labels, and ordering, including exclusion of empty countries and correct handling of the “non-organization” option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->