### PR TITLE
Fix: Support multiple charge records in CAMT files.

### DIFF
--- a/django/geno/sepa_reader.py
+++ b/django/geno/sepa_reader.py
@@ -28,13 +28,12 @@ def read_camt_transaction(data, tr, date_str, entry_ref=None):
     if "charges" in tr:
         if "total" in tr["charges"]:
             charges = tr["charges"]["total"]
-        elif tr["charges"].get("record", []):
-            if len(tr["charges"]["record"]) == 1:
-                charges = tr["charges"]["record"][0]["amount"]["_value"]
-            else:
-                raise SepaReaderException(
-                    "More than one charge record: %s %s" % (tx_id, tr["charges"])
-                )
+        else:
+            total = 0
+            for charge in tr["charges"].get("record", []):
+                total += float(charge.get("amount", {}).get("_value", 0))
+            if total:
+                charges = f"{total:.2f}"
     if "related_parties" not in tr or "debtor" not in tr["related_parties"]:
         return [
             "Ignoring transaction without debtor: %s" % tr["amount"]["_value"],

--- a/django/geno/tests/camt_files/camt.054_CH5600790016583351934_2025-06-27_00070_with_multiple_charges.xml
+++ b/django/geno/tests/camt_files/camt.054_CH5600790016583351934_2025-06-27_00070_with_multiple_charges.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <BkToCstmrDbtCdtNtfctn>
+        <GrpHdr>
+            <MsgId>161935259201_1</MsgId>
+            <CreDtTm>2025-06-28T01:31:37.086+02:00</CreDtTm>
+            <MsgPgntn>
+                <PgNb>1</PgNb>
+                <LastPgInd>true</LastPgInd>
+            </MsgPgntn>
+            <AddtlInf>SPS/PROD</AddtlInf>
+        </GrpHdr>
+        <Ntfctn>
+            <Id>161935259201</Id>
+            <CreDtTm>2025-06-28T01:31:37.086+02:00</CreDtTm>
+            <FrToDt>
+                <FrDtTm>2020-07-13T00:00:00.000+02:00</FrDtTm>
+                <ToDtTm>2025-07-10T02:00:00.000+02:00</ToDtTm>
+            </FrToDt>
+            <RptgSrc>
+                <Prtry>C53F</Prtry>
+            </RptgSrc>
+            <Acct>
+                <Id>
+                    <IBAN>CH5600790000000351934</IBAN>
+                </Id>
+                <Ccy>CHF</Ccy>
+                <Ownr>
+                    <Nm>Muster-Genossenschaft</Nm>
+                    <PstlAdr>
+                        <StrtNm>Musterstrasse 257</StrtNm>
+                        <PstCd>3018</PstCd>
+                        <TwnNm>Bern</TwnNm>
+                    </PstlAdr>
+                </Ownr>
+            </Acct>
+            <Ntry>
+                <NtryRef>CH7830790000000351934</NtryRef>
+                <Amt Ccy="CHF">50.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2025-06-28</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2025-06-28</Dt>
+                </ValDt>
+                <AcctSvcrRef>424500009094184744</AcctSvcrRef>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>RCDT</Cd>
+                            <SubFmlyCd>VCOM</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <AcctSvcrRef>424500009094184743</AcctSvcrRef>
+                            <AcctSvcrTxId>424500009094184743</AcctSvcrTxId>
+                        </Refs>
+                        <Amt Ccy="CHF">50.00</Amt>
+                        <CdtDbtInd>CRDT</CdtDbtInd>
+                        <BkTxCd>
+                            <Domn>
+                                <Cd>PMNT</Cd>
+                                <Fmly>
+                                    <Cd>RCDT</Cd>
+                                    <SubFmlyCd>ATXN</SubFmlyCd>
+                                </Fmly>
+                            </Domn>
+                        </BkTxCd>
+                        <Chrgs>
+                            <Rcrd>
+                                <Amt Ccy="CHF">1.20</Amt>
+                                <ChrgInclInd>false</ChrgInclInd>
+                                <Tp>
+                                    <Prtry>
+                                        <Id>2</Id>
+                                    </Prtry>
+                                </Tp>
+                            </Rcrd>
+                            <Rcrd>
+                                <Amt Ccy="CHF">0.04</Amt>
+                                <ChrgInclInd>false</ChrgInclInd>
+                                <Tp>
+                                    <Prtry>
+                                        <Id>4</Id>
+                                    </Prtry>
+                                </Tp>
+                            </Rcrd>
+                            <Rcrd>
+                                <Amt Ccy="CHF">0.80</Amt>
+                                <ChrgInclInd>false</ChrgInclInd>
+                                <Tp>
+                                    <Prtry>
+                                        <Id>5</Id>
+                                    </Prtry>
+                                </Tp>
+                            </Rcrd>
+                        </Chrgs>
+                        <RltdPties>
+                            <Dbtr>
+                                <Nm>Hans Muster</Nm>
+                                <PstlAdr>
+                                    <AdrLine>Musterweg 9</AdrLine>
+                                    <AdrLine>CH-3004 Bern</AdrLine>
+                                </PstlAdr>
+                            </Dbtr>
+                        </RltdPties>
+                        <RltdAgts>
+                            <DbtrAgt>
+                                <FinInstnId>
+                                    <BICFI>BCLRCHBBXXX</BICFI>
+                                    <Nm>Bank Taler AG</Nm>
+                                    <PstlAdr>
+                                        <Ctry>CH</Ctry>
+                                        <AdrLine>4000 Basel</AdrLine>
+                                    </PstlAdr>
+                                </FinInstnId>
+                            </DbtrAgt>
+                        </RltdAgts>
+                        <RmtInf>
+                            <Strd>
+                                <CdtrRefInf>
+                                    <Tp>
+                                        <CdOrPrtry>
+                                            <Prtry>QRR</Prtry>
+                                        </CdOrPrtry>
+                                    </Tp>
+                                    <Ref>360000000002000000003620253</Ref>
+                                </CdtrRefInf>
+                                <AddtlRmtInf>Jahresbeitrag 2025 mit Gebühren</AddtlRmtInf>
+                            </Strd>
+                        </RmtInf>
+                    </TxDtls>
+                </NtryDtls>
+                <AddtlNtryInf>Zahlungseingang QRR</AddtlNtryInf>
+            </Ntry>
+        </Ntfctn>
+    </BkToCstmrDbtCdtNtfctn>
+</Document>

--- a/django/geno/tests/test_sepa_reader.py
+++ b/django/geno/tests/test_sepa_reader.py
@@ -88,6 +88,18 @@ class SepaReaderTest(GenoAdminTestCase):
                     "date": datetime.date(2025, 6, 28),
                 },
             },
+            {
+                "file": "camt.054_CH5600790016583351934_2025-06-27_00070_with_multiple_charges.xml",
+                "num_transactions": 1,
+                "data": {
+                    "amount": "50.00",
+                    "reference_nr": "360000000002000000003620253",
+                    "debtor": "Hans Muster",
+                    "extra_info": "Jahresbeitrag 2025 mit Gebühren",
+                    "charges": "2.04",  # 1.20 + 0.04 + 0.80
+                    "date": datetime.date(2025, 6, 28),
+                },
+            },
         ]
 
         for testfile in testfiles:


### PR DESCRIPTION
So far we only accepted one charge record (for unknown reasons) in CAMT payment files. With this fix multiple charges are supported by adding them together.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
