### PR TITLE
Make ALTCHA captcha field available and use it in registration form.

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -77,6 +77,8 @@ If you need to set up step-by-step or are preparing a production deployment, fol
 ## Install required system packages
 
 Supported Python versions: 3.11 – 3.13
+Supported MariaDB version: 10.7+
+Supported Redis version: 6+
 
 Example for Debian 11 (should work on most Debian/Ubuntu based systems):
 

--- a/django/cohiva/settings_defaults.py
+++ b/django/cohiva/settings_defaults.py
@@ -13,6 +13,8 @@ NOTE: Settings are cascaded in the following order (settings in the later files 
 """
 
 import datetime
+import hashlib
+import hmac
 import locale
 from pathlib import Path
 from urllib.parse import quote
@@ -222,6 +224,7 @@ INSTALLED_APPS = (
     "django.contrib.staticfiles",
     "crispy_forms",  # For Unfold forms
     "email_obfuscator",
+    "django_altcha",
     "django_tables2",
     "select2",
     "datetimewidget",
@@ -631,6 +634,13 @@ CELERY_BROKER_URL = "redis://localhost:6379/0"
 #   'global_keyprefix': 'cohiva_'
 # }
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": "redis://localhost:6379",
+    }
+}
+
 ## Cohiva specific config
 COHIVA_FEATURES = cbc.FEATURES
 COHIVA_SITE_NICKNAME = cbc.SITE_NICKNAME
@@ -1039,6 +1049,16 @@ WAGTAILADMIN_BASE_URL = BASE_URL
 WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
 WAGTAILDOCS_EXTENSIONS = ["csv", "docx", "key", "odt", "pdf", "pptx", "rtf", "txt", "xlsx", "zip"]
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10_000
+
+# For django-altcha CAPTCHA fields (https://github.com/aboutcode-org/django-altcha#usage)
+# By default we derive the key from SITE_SECRET, you can override it in settings.py if you
+# want to specify an independent secret.
+ALTCHA_HMAC_KEY = hmac.new(
+    key=SECRET_KEY.encode("utf-8"),
+    msg=b"django-altcha-key-v1",  # Fixed context string for domain separation
+    digestmod=hashlib.sha256,
+).hexdigest()
+ALTCHA_INCLUDE_TRANSLATIONS = True
 
 ## Silence warning about MySQL constraints
 SILENCED_SYSTEM_CHECKS = [

--- a/django/cohiva/settings_example_docker_compose.py
+++ b/django/cohiva/settings_example_docker_compose.py
@@ -6,13 +6,14 @@ Inherits from settings_defaults and overrides necessary configurations.
 import os
 
 from .settings_defaults import *  # noqa: F403
-from .settings_defaults import CORS_ALLOWED_ORIGINS
+from .settings_defaults import CACHES, CORS_ALLOWED_ORIGINS
 
 # Instance-specific configuration
 COHIVA_INSTANCE_PATH = os.environ.get("COHIVA_INSTANCE_PATH", "/instance_files/override_files")
 
-# Override Celery broker for Docker Compose networking
+# Override Celery broker and default cache for Docker Compose networking
 CELERY_BROKER_URL = "redis://redis:6379/0"
+CACHES["default"]["LOCATION"] = "redis://redis:6379"
 
 # Static files configuration for Docker Compose
 STATIC_ROOT = "/tmp/static"

--- a/django/cohiva/settings_for_tests.py
+++ b/django/cohiva/settings_for_tests.py
@@ -109,3 +109,6 @@ GENO_QRBILL_CREDITOR = {
 
 if "importer" not in INSTALLED_APPS:
     INSTALLED_APPS += ("importer",)
+
+# Disable CAPTCHA for tests
+ALTCHA_VERIFICATION_ENABLED = False

--- a/django/geno/forms.py
+++ b/django/geno/forms.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.formats import date_format
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
+from django_altcha import AltchaField
 from unfold.widgets import (
     UnfoldAdminDateWidget,
     UnfoldAdminDecimalFieldWidget,
@@ -814,6 +815,8 @@ class RegistrationFormSlotField(forms.ModelChoiceField):
 
 
 class RegistrationForm(forms.ModelForm):
+    captcha = AltchaField(debug=False, hidelogo=True, hidefooter=True, auto="onload")
+
     class Meta:
         model = Registration
         fields = (

--- a/django/geno/tests/data.py
+++ b/django/geno/tests/data.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import TYPE_CHECKING
 
 from django.contrib.auth.models import User
 from django.utils import timezone
@@ -23,8 +24,10 @@ from geno.models import (
     Tenant,
 )
 from geno.tests.base import GenoAdminTestCase
-from geno.tests.test_registration import TestRegistrationForm
 from reservation.tests.base import ReservationTestCase
+
+if TYPE_CHECKING:
+    from geno.tests.test_registration import TestRegistrationForm
 
 
 def create_users(cls: type[GenoAdminTestCase]):
@@ -534,7 +537,7 @@ def create_sharetypes(cls: type[GenoAdminTestCase]):
     cls.sharetypes.append(ShareType.objects.create(name="Anteilschein freiwillig"))
 
 
-def create_registrationevents(cls: type[TestRegistrationForm]):
+def create_registrationevents(cls: "type[TestRegistrationForm]"):
     cls.registrationevents = []
     cls.registrationevents.append(
         RegistrationEvent.objects.create(

--- a/django/requirements-docker.txt
+++ b/django/requirements-docker.txt
@@ -14,6 +14,8 @@ aiosignal==1.4.0
     # via aiohttp
 aiostream==0.4.5
     # via vdirsyncer
+altcha==1.0.0
+    # via django-altcha
 amqp==5.3.1
     # via kombu
 anyascii==0.3.3
@@ -115,6 +117,8 @@ django==5.2.15
     #   easy-thumbnails
     #   laces
     #   wagtail
+django-altcha==1.0.0
+    # via -r requirements.in
 django-cogwheels==0.3
     # via wagtailmenus
 django-cors-headers==4.7.0

--- a/django/requirements.in
+++ b/django/requirements.in
@@ -30,6 +30,7 @@ django-datetime-widget
 django-email-obfuscator
 django-unfold
 django-crispy-forms
+django-altcha
 
 ## File manager app
 django-filer

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -12,6 +12,8 @@ aiosignal==1.4.0
     # via aiohttp
 aiostream==0.4.5
     # via vdirsyncer
+altcha==1.0.0
+    # via django-altcha
 amqp==5.3.1
     # via kombu
 anyascii==0.3.3
@@ -104,6 +106,7 @@ django==5.2.15
     # via
     #   -r requirements.in
     #   dj-rest-auth
+    #   django-altcha
     #   django-cors-headers
     #   django-crispy-forms
     #   django-datetime-widget
@@ -124,6 +127,8 @@ django==5.2.15
     #   easy-thumbnails
     #   laces
     #   wagtail
+django-altcha==1.0.0
+    # via -r requirements.in
 django-cogwheels==0.3
     # via wagtailmenus
 django-cors-headers==4.7.0

--- a/django/website_example/templates/website/base.html
+++ b/django/website_example/templates/website/base.html
@@ -36,7 +36,7 @@ ul.errorlist {
   background: #f5dd5d94;
   padding-left: 6px;
   font-weight: bold;
-} 
+}
 
 ul.confirmationlist {
   color: #44b9ad;
@@ -56,7 +56,6 @@ form.bigform input, textarea {
   max-width: 400px;
   margin: 0;
   padding: 5px;
-  margin-bottom: 10px;
   vertical-align: baseline;
 }
 form.bigform input[type="checkbox"] {
@@ -75,6 +74,11 @@ form ul {
 form ul li {
   margin-left: 0px;
   list-style-type: none;
+  margin-bottom: 10px;
+}
+
+form .altcha {
+  margin-top: 10px;
 }
 
         </style>


### PR DESCRIPTION
- Add a mechanism to protect public forms with an ALTCHA captcha.
- Use the captcha in the registration form.
- Add default configuration with redis as cache backend.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CAPTCHA protection to registration forms for improved abuse prevention.
  * Enabled a Redis-backed cache for faster app response and better session/data handling.

* **Bug Fixes**
  * Fixed form and error-list spacing in shared page styling for cleaner layout.
  * Adjusted CAPTCHA spacing so it displays more consistently in forms.

* **Chores**
  * Updated application dependencies to include the new CAPTCHA support package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->