### PR TITLE
Remove default value for GENO_SMALL_NUMBER_OF_SHARES_CUTOFF

### DIFF
--- a/django/cohiva/settings_defaults.py
+++ b/django/cohiva/settings_defaults.py
@@ -920,7 +920,7 @@ GENO_SHARE_LETTER_CUTOFF_DATE = datetime.date(2018, 7, 1)
 
 # When creating statements, treat persons differently if they own only up to this
 # number of shares (and they have no loans etc).
-GENO_SMALL_NUMBER_OF_SHARES_CUTOFF = 5
+# GENO_SMALL_NUMBER_OF_SHARES_CUTOFF = 5
 
 GENO_MEMBER_FLAGS = {
     1: "Wohnen",

--- a/django/geno/shares.py
+++ b/django/geno/shares.py
@@ -99,7 +99,7 @@ def get_share_statement_data(adr, year, enddate=None):
         statement_data["s_shares_bvg"] = inter["bvg_amount"][0]
         if statement_data["s_shares_bvg"] > 0:
             statement_data["sect_bvg"] = True
-        if statement_data["n_shares"] > settings.GENO_SMALL_NUMBER_OF_SHARES_CUTOFF:
+        if statement_data["n_shares"] > getattr(settings, "GENO_SMALL_NUMBER_OF_SHARES_CUTOFF", 0):
             statement_data["thankyou"] = True
     if inter["end_amount"][1]:
         ## Zinslose Darlehen

--- a/django/geno/tests/test_views.py
+++ b/django/geno/tests/test_views.py
@@ -445,22 +445,28 @@ class ShareStatementViewTest(GenoAdminTestCase):
         view = ShareStatementView()
         view.enddate = datetime.date(2020, 12, 31)
         obj = view.get_objects()
-        self.assertEqual(len(obj), 2)
-        self.assertIn("Anzahl ignoriert=2", view.extra_description_info)
-
-        Share.objects.create(
-            value=500,
-            quantity=1,
-            share_type=ShareType.objects.get(name="Depositenkasse"),
-            date=datetime.date(2020, 1, 1),
-            name=self.addresses[1],
-            state="bezahlt",
-        )
-        obj = view.get_objects()
-        self.assertEqual(len(obj), 3)
-        self.assertIn("Anzahl ignoriert=1", view.extra_description_info)
-
-        view.address_id = self.addresses[0].pk
-        obj = view.get_objects()
-        self.assertEqual(len(obj), 1)
+        # Default is no cutoff => no skips
+        self.assertEqual(len(obj), 4)
         self.assertIn("Anzahl ignoriert=0", view.extra_description_info)
+
+        with self.settings(GENO_SMALL_NUMBER_OF_SHARES_CUTOFF=5):
+            obj = view.get_objects()
+            self.assertEqual(len(obj), 2)
+            self.assertIn("Anzahl ignoriert=2", view.extra_description_info)
+
+            Share.objects.create(
+                value=500,
+                quantity=1,
+                share_type=ShareType.objects.get(name="Depositenkasse"),
+                date=datetime.date(2020, 1, 1),
+                name=self.addresses[1],
+                state="bezahlt",
+            )
+            obj = view.get_objects()
+            self.assertEqual(len(obj), 3)
+            self.assertIn("Anzahl ignoriert=1", view.extra_description_info)
+
+            view.address_id = self.addresses[0].pk
+            obj = view.get_objects()
+            self.assertEqual(len(obj), 1)
+            self.assertIn("Anzahl ignoriert=0", view.extra_description_info)


### PR DESCRIPTION
The default value was 5 for historical reasons (from one specific instance). The new default is no cutoff.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed share statement cutoff handling when the cutoff setting is not configured, preventing runtime errors.
  * Share statements now apply a safe default cutoff behavior to keep results consistent.
* **Tests**
  * Expanded coverage to verify both default (no cutoff) and configured cutoff scenarios, including address-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->