### PR TITLE
COHIV-254: make Selector elements resizeable

### DIFF
--- a/django/cohiva/settings_defaults.py
+++ b/django/cohiva/settings_defaults.py
@@ -1413,9 +1413,9 @@ UNFOLD = {
     "STYLES": [
         lambda request: static("css/cohiva_style.css"),
     ],
-    #    "SCRIPTS": [
-    #        lambda request: static("js/script.js"),
-    #    ],
+    "SCRIPTS": [
+        lambda request: static("geno/js/selector_resize.js"),
+    ],
     #    "BORDER_RADIUS": "6px",
     #    "COLORS": {
     #        "base": {

--- a/django/geno/static/css/cohiva_style.css
+++ b/django/geno/static/css/cohiva_style.css
@@ -19,3 +19,17 @@
 :root {
   --default-button-bg: var(--color-primary-600);
 }
+
+/* Vertically resizable selector — browser-native resize handle at bottom-right */
+.selector {
+  resize: vertical;
+  overflow: hidden;
+  min-height: 13em; /* ~4 visible options + title/filter/button chrome */
+}
+
+/* Select boxes fill remaining column height instead of using a fixed em value */
+.selector select.filtered {
+  flex: 1 1 0;
+  height: 0;
+  min-height: 0;
+}

--- a/django/geno/static/geno/js/selector_resize.js
+++ b/django/geno/static/geno/js/selector_resize.js
@@ -1,18 +1,24 @@
+/*
+ * IIFE to automatically adjust the initial height of .selector elements, and
+ * add CSS-native resize handles to the container.
+ */
 (function () {
+    // Ensure all .selector elements have a height set at initialisation time
     function initSelectors() {
         document.querySelectorAll('.selector').forEach(function (el) {
             var h = el.getBoundingClientRect().height;
-            if (h > 0 && !el.style.height) el.style.height = h + 'px';
+            if (h > 0 && !el.style.height) el.style.height = h * 1.2 + 'px';
         });
     }
 
+    // Only execute after the DOM is ready
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', initSelectors);
     } else {
         initSelectors();
     }
 
-    // Pin height for selectors added later (inline formsets)
+    // Handle dynamically added .selector elements (e.g. inline formsets)
     var observer = new MutationObserver(function (mutations) {
         var needsInit = false;
         mutations.forEach(function (m) {

--- a/django/geno/static/geno/js/selector_resize.js
+++ b/django/geno/static/geno/js/selector_resize.js
@@ -1,0 +1,32 @@
+(function () {
+    function initSelectors() {
+        document.querySelectorAll('.selector').forEach(function (el) {
+            var h = el.getBoundingClientRect().height;
+            if (h > 0 && !el.style.height) el.style.height = h + 'px';
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initSelectors);
+    } else {
+        initSelectors();
+    }
+
+    // Pin height for selectors added later (inline formsets)
+    var observer = new MutationObserver(function (mutations) {
+        var needsInit = false;
+        mutations.forEach(function (m) {
+            m.addedNodes.forEach(function (node) {
+                if (node.nodeType === 1 &&
+                    (node.classList.contains('selector') || node.querySelector('.selector'))) {
+                    needsInit = true;
+                }
+            });
+        });
+        if (needsInit) initSelectors();
+    });
+
+    document.addEventListener('DOMContentLoaded', function () {
+        observer.observe(document.body, { childList: true, subtree: true });
+    });
+})();


### PR DESCRIPTION
Increase the base height of Selector UI elements, and make them resizeable to improve usability for very long lists of options.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
