### PR TITLE
Make uuid field migrations reversible and fix invalid values before adding DB constraint

### DIFF
--- a/django/geno/migrations/0024_member_name_to_fk_and_date_constraint.py
+++ b/django/geno/migrations/0024_member_name_to_fk_and_date_constraint.py
@@ -4,12 +4,23 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 
+def fix_date_leave(apps, schema_editor):
+    member_model = apps.get_model("geno", "member")
+    for member in member_model.objects.filter(date_leave__lt=models.F("date_join")):
+        info = f"Ungültiges Austrittsdatum {member.date_leave} mit Beitrittsdatum ersetzt."
+        member.notes = f"{info}\n{member.notes}"
+        member.date_leave = member.date_join
+        member.save()
+        print(f"Member {member.id}: {info}")
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("geno", "0023_address_ahv_number_rentalunit_billing_period_and_more"),
     ]
 
     operations = [
+        migrations.RunPython(fix_date_leave, reverse_code=migrations.RunPython.noop),
         migrations.AlterField(
             model_name="member",
             name="name",

--- a/django/geno/migrations/0026_convert_uuids_from_char.py
+++ b/django/geno/migrations/0026_convert_uuids_from_char.py
@@ -18,5 +18,8 @@ class Migration(migrations.Migration):
             sql="""
             ALTER TABLE geno_address MODIFY random_id UUID NOT NULL;
             """,
+            reverse_sql="""
+            ALTER TABLE geno_address MODIFY random_id CHAR(36) NOT NULL;
+            """,
         )
     ]

--- a/django/report/migrations/0003_convert_uuids_from_char.py
+++ b/django/report/migrations/0003_convert_uuids_from_char.py
@@ -18,5 +18,8 @@ class Migration(migrations.Migration):
             sql="""
             ALTER TABLE report_report MODIFY task_id UUID NULL;
             """,
+            reverse_sql="""
+            ALTER TABLE report_report MODIFY task_id CHAR(36) NULL;
+            """,
         )
     ]


### PR DESCRIPTION
Fix migrations:
- Make migrations of CHAR to UUID fields reversible.
- Fix invalid values of `Member.date_leave` before adding a new constraint in order to avoid failing migrations with IntegrityError.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected member records with exit dates earlier than their join dates.
  * Added validation to prevent invalid date ranges.

* **Database Improvements**
  * Added rollback support for UUID storage conversions.
  * Improved migration reliability when changes need to be reversed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->