### PR TITLE
COHIV-221: improve search behaviour for Address model

### DIFF
--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -431,7 +431,7 @@ class AddressAdmin(GenoBaseAdmin):
             queryset = queryset.annotate(
                 _search_rank = Case(
                     When(
-                        Q(name__contains=search_term) | Q(first_name__contains=search_term),
+                        Q(name__icontains=search_term) | Q(first_name__icontains=search_term),
                         then=Value(0),
                     ),
                     default=Value(1),

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -424,6 +424,9 @@ class AddressAdmin(GenoBaseAdmin):
     ]
 
     def get_search_results(self, request, queryset, search_term):
+        # Remove commas from the search term to allow hits for terms in the
+        # form "Last Name, First Name".
+        search_term = search_term.replace(",", " ")
         queryset, use_distinct = super().get_search_results(request, queryset, search_term)
         if search_term:
             # Add an integer search "ranking" according to the field that the
@@ -431,13 +434,15 @@ class AddressAdmin(GenoBaseAdmin):
             queryset = queryset.annotate(
                 _search_rank = Case(
                     When(
-                        Q(name__icontains=search_term) | Q(first_name__icontains=search_term),
+                        Q(name__icontains=search_term)
+                        | Q(first_name__icontains=search_term)
+                        | Q(organization__icontains=search_term),
                         then=Value(0),
                     ),
                     default=Value(1),
                     output_field=IntegerField(),
                 )
-            ).order_by("_search_rank", "name", "first_name")
+            ).order_by("_search_rank", "name", "first_name", "organization")
         return queryset, use_distinct
 
     @action(

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -10,6 +10,7 @@ from django.contrib import admin, messages
 from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import Group, User
+from django.db.models import Case, IntegerField, Q, Value, When
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -421,6 +422,23 @@ class AddressAdmin(GenoBaseAdmin):
             # "variant": ActionVariant.PRIMARY,
         },
     ]
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        if search_term:
+            # Add an integer search "ranking" according to the field that the
+            # search term matches on.
+            queryset = queryset.annotate(
+                _search_rank = Case(
+                    When(
+                        Q(name__contains=search_term) | Q(first_name__contains=search_term),
+                        then=Value(0),
+                    ),
+                    default=Value(1),
+                    output_field=IntegerField(),
+                )
+            ).order_by("_search_rank", "name", "first_name")
+        return queryset, use_distinct
 
     @action(
         description=_("Export"),

--- a/django/geno/tests/test_admin.py
+++ b/django/geno/tests/test_admin.py
@@ -540,7 +540,10 @@ class AddressAdminSearchTest(GenoAdminTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.adr = Address.objects.create(name="Alder", first_name="Annika")
+        cls.adr = Address.objects.create(name="Alder", first_name="Alice")
+        cls.adr_name_in_comment = Address.objects.create(
+            name="Barter", first_name="Bob", comment="Friend of the Alder family"
+        )
         cls.adr_comment_inline = Address.objects.create(
             name="CommentInline", comment="A test comment, with a comma"
         )
@@ -559,28 +562,39 @@ class AddressAdminSearchTest(GenoAdminTestCase):
         queryset, _ = model_admin.get_search_results(request, Address.objects.all(), search_term)
         return queryset
 
+    def test_search_by_first_name(self):
+        qs = self._search("Alice")
+        self.assertIn(self.adr, qs)
+        # The resulting row should have _search_rank == 0, because it matched on
+        # the `first_name` field.
+        self.assertEqual(qs.get(pk=self.adr.pk)._search_rank, 0)
+
     def test_search_by_name(self):
         qs = self._search("Alder")
         self.assertIn(self.adr, qs)
-
-    def test_search_by_first_name(self):
-        qs = self._search("Annika")
-        self.assertIn(self.adr, qs)
+        # The `name` match has a higher _search_rank than the `comment` match
+        self.assertEqual(qs.get(pk=self.adr.pk)._search_rank, 0)
+        self.assertEqual(qs.get(pk=self.adr_name_in_comment.pk)._search_rank, 1)
 
     def test_search_name_comma_first_name(self):
-        # The UI displays the name as "Alder, Annika" -- the comma should not
+        # The UI displays the name as "Alder, Alice" -- the comma should not
         # prevent this row from appearing.
-        qs = self._search("Alder, Annika")
+        qs = self._search("Alder, Alice")
         self.assertIn(self.adr, qs)
+        # The resulting row should have _search_rank == 1, because the search
+        # term matched partially on both the `name` and `first_name` fields, but
+        # not wholly on both.
+        self.assertEqual(qs.get(pk=self.adr.pk)._search_rank, 1)
 
     def test_search_first_name_comma_name(self):
         # Reversed order also works after comma stripping
-        qs = self._search("Annika, Alder")
+        qs = self._search("Alice, Alder")
         self.assertIn(self.adr, qs)
+        self.assertEqual(qs.get(pk=self.adr.pk)._search_rank, 1)
 
     def test_search_name_comma_no_false_positive(self):
-        # "Alder, Annika" should not return unrelated addresses
-        qs = self._search("Alder, Annika")
+        # "Alder, Alice" should not return unrelated addresses
+        qs = self._search("Alder, Alice")
         self.assertNotIn(self.adr_comment_inline, qs)
         self.assertNotIn(self.adr_comment_leading, qs)
         self.assertNotIn(self.adr_comment_multi, qs)

--- a/django/geno/tests/test_admin.py
+++ b/django/geno/tests/test_admin.py
@@ -534,3 +534,71 @@ class GenoAdminTest(GenoAdminTestCase):
 
         es_tuple = next(item for item in lookups if item[0] == "ES")
         self.assertEqual(es_tuple[1], "Spanien")
+
+
+class AddressAdminSearchTest(GenoAdminTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.adr = Address.objects.create(name="Alder", first_name="Annika")
+        cls.adr_comment_inline = Address.objects.create(
+            name="CommentInline", comment="A test comment, with a comma"
+        )
+        cls.adr_comment_leading = Address.objects.create(
+            name="CommentLeading", comment=",,,Comment with leading commas"
+        )
+        cls.adr_comment_multi = Address.objects.create(
+            name="CommentMulti", comment="A test comment,,,with multiple commas"
+        )
+
+    def _search(self, search_term):
+        factory = RequestFactory()
+        request = factory.get("/admin/geno/address/")
+        request.user = self.su
+        model_admin = admin.AddressAdmin(Address, django_admin.site)
+        queryset, _ = model_admin.get_search_results(request, Address.objects.all(), search_term)
+        return queryset
+
+    def test_search_by_name(self):
+        qs = self._search("Alder")
+        self.assertIn(self.adr, qs)
+
+    def test_search_by_first_name(self):
+        qs = self._search("Annika")
+        self.assertIn(self.adr, qs)
+
+    def test_search_name_comma_first_name(self):
+        # The UI displays the name as "Alder, Annika" -- the comma should not
+        # prevent this row from appearing.
+        qs = self._search("Alder, Annika")
+        self.assertIn(self.adr, qs)
+
+    def test_search_first_name_comma_name(self):
+        # Reversed order also works after comma stripping
+        qs = self._search("Annika, Alder")
+        self.assertIn(self.adr, qs)
+
+    def test_search_name_comma_no_false_positive(self):
+        # "Alder, Annika" should not return unrelated addresses
+        qs = self._search("Alder, Annika")
+        self.assertNotIn(self.adr_comment_inline, qs)
+        self.assertNotIn(self.adr_comment_leading, qs)
+        self.assertNotIn(self.adr_comment_multi, qs)
+
+    # Verify that stripping commas for the sake of matching Name, First Name
+    # does not adversely affect matching on other fields where commas are likely
+    # to appear, such as "Comment"
+    def test_search_comment_with_inline_comma(self):
+        # Searching text around a comma in a comment still returns the row
+        qs = self._search("test comment, with")
+        self.assertIn(self.adr_comment_inline, qs)
+
+    def test_search_comment_with_leading_commas(self):
+        # Leading commas in a search term are stripped, leaving plain keywords
+        qs = self._search(",,, Comment leading commas")
+        self.assertIn(self.adr_comment_leading, qs)
+
+    def test_search_comment_with_multiple_commas(self):
+        # Multiple consecutive commas are stripped; all remaining words must match
+        qs = self._search("test comment,,,with multiple commas")
+        self.assertIn(self.adr_comment_multi, qs)


### PR DESCRIPTION
**Current behaviour:** when UI elements that rely on the Address model are searched, they return all rows that match the search term, sorted by the Organisation column. For individuals, this is "Last name, First name". When searching for an Address by name, rows that are returned due to a match on another column (e.g. the Comment column) may appear above matches on the queried name, due to this sorting.

Further, searching for the exact string "Last name, First name" returns zero matches, due to the inclusion of the `,` character. Django splits the search term on whitespace by default, and looks for matches on `['Last name,', 'First name']`.

**Proposed behaviour:** UI elements that rely on the Address model prioritise matches on the `name`, `first_name`, and `organization` fields, and ensure these matches appear before matches on any other field.

Commas are (silently) stripped from search terms, in order to ensure users can find matches for names when they are entered exactly as they appear in the UI. This does not adversely affect search on fields where commas are more likely to appear, e.g. `comment`.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved address search to rank matches by name, first name, and organization.
  - Search terms containing commas are now handled more naturally.
  - Results are ordered by relevance, followed by address details.

- **Bug Fixes**
  - Fixed comma-containing searches that could miss valid matches or return false positives.
  - Improved matching for comments with leading, inline, or repeated commas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->