### PR TITLE
COHIV-248: warn when exiting page with unsaved changes

### DIFF
--- a/django/cohiva/settings_defaults.py
+++ b/django/cohiva/settings_defaults.py
@@ -454,9 +454,9 @@ STORAGES = {
 }
 
 # Additional locations of static files
-# STATICFILES_DIRS = (
-#    BASE_DIR / 'static',
-# )
+STATICFILES_DIRS = (
+   BASE_DIR / "cohiva/static",
+)
 
 ## List of finder classes that know how to find static files in
 ## various locations.

--- a/django/cohiva/static/admin/js/unsaved_changes.js
+++ b/django/cohiva/static/admin/js/unsaved_changes.js
@@ -1,0 +1,12 @@
+(function () {
+    let dirty = false;
+
+    document.addEventListener("change", () => { dirty = true; });
+    document.addEventListener("submit", () => { dirty = false; });
+
+    window.addEventListener("beforeunload", (e) => {
+        if (dirty) {
+            e.preventDefault();
+        }
+    });
+})();

--- a/django/cohiva/templates/admin/base_site.html
+++ b/django/cohiva/templates/admin/base_site.html
@@ -1,4 +1,5 @@
 {% extends "admin/base_site.html" %}
+{% load static %}
 {% block extrahead %}
     <style>
         .select2-container {
@@ -55,4 +56,5 @@
         }
 
     </style>
+    <script src="{% static 'admin/js/unsaved_changes.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
**Current behaviour:** navigating away from an Admin form with unsaved changes does not warn or otherwise prompt the user, which can cause loss of data.

**Proposed behaviour:** if the user attempts to navigate away from a "dirty" form with unsaved changes, a warning popup appears, asking for confirmation.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unsaved-changes protection to the administration interface. When leaving a page with unsubmitted edits, the browser now displays a confirmation prompt.
  - The warning clears after changes are submitted, preventing unnecessary prompts.
- **Improvements**
  - Enhanced administration pages to reliably load their static assets and supporting scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->