### PR TITLE
COHIV-307: Optimize rent invoice creation and improve logging

### DIFF
--- a/django/geno/api_views.py
+++ b/django/geno/api_views.py
@@ -427,7 +427,6 @@ class QRBill(APIView):
         self.context["generic_info"] = request.data["bill_lines"]
         self.context["s_generic_total"] = nformat(total_amount)
         self.context["qr_extra_info"] = "Rechnung %s" % self.context["invoice_nr"]
-        self.context["preview"] = self.dry_run
 
         (ret, mails_sent, mail_recipient) = create_qrbill(
             ref_number,

--- a/django/geno/billing.py
+++ b/django/geno/billing.py
@@ -329,6 +329,8 @@ def create_monthly_invoices(book, contract, reference_date, invoice_category, op
             ru_list.append(",".join(ru_names) + "; " + building.name)
 
         if factor > 0.0:
+            if not dry_run:
+                logger.info(f"Creating invoices for contract {contract.id} / {invoice_date}")
             if factor != 1.0:
                 factor_txt = " (Faktor %.2f)" % factor
             else:
@@ -1752,6 +1754,7 @@ def create_qrbill(
         context["qr_account"] = settings.FINANCIAL_ACCOUNTS[AccountKey.DEFAULT_DEBTOR]["iban"]
         context["qr_ref_number"] = ref_number
         context["qr_debtor"] = address
+        context["preview"] = dry_run
         try:
             invoice_doctype = DocumentType.objects.get(name="invoice")
             render_qrbill(
@@ -1766,6 +1769,10 @@ def create_qrbill(
                 0,
                 None,
             )
+        logger.info(
+            f"Rendered QR-Bill for {address} (ref. {ref_number}, {output_filename}), "
+            f"dry_run/preview={dry_run}"
+        )
 
     messages = []
     mails_sent = 0
@@ -1809,23 +1816,35 @@ def create_qrbill(
                         mails_sent = 1
                     else:
                         mails_sent = mail.send()
+                        if mails_sent:
+                            logger.info(
+                                f"Sent QR-Bill to {mail_recipient} (ref. {ref_number}), "
+                                f"mails_sent={mails_sent}"
+                            )
+                        else:
+                            logger.error(
+                                f"Error while sending mail to {mail_recipient}: "
+                                f"mails_sent={mails_sent}"
+                            )
 
                 except SMTPException as e:
                     messages.append(
                         "Konnte mail an %s nicht schicken!!! SMTP-Fehler: %s"
                         % (escape(mail_recipient), e)
                     )
+                    logger.error(f"SMTP error while sending mail to {mail_recipient}: {e}")
                     mails_sent = 0
                 except Exception as e:
                     messages.append(
                         "Konnte mail an %s nicht schicken!!! Allgemeiner Fehler: %s"
                         % (escape(mail_recipient), e)
                     )
+                    logger.error(f"Error while sending mail to {mail_recipient}: {e}")
                     mails_sent = 0
             else:
                 mails_sent = 1
 
-    return (messages, mails_sent, mail_recipient)
+    return messages, mails_sent, mail_recipient
 
 
 def create_qrbill_rent(
@@ -1851,6 +1870,12 @@ def create_qrbill_rent(
         render = True
 
     address = contract.get_contact_address()
+    if not address.email:
+        # We don't need to continue if there is no email address, since we cannot send
+        # the document that would be created here.
+        messages = [f"KEIN EMAIL GESENDET! Grund: Keine E-Mail-Adresse für {address} vorhanden."]
+        output_filename = None
+        return messages, output_filename
 
     context = address.get_context()
     context["betreff"] = title

--- a/django/geno/billing.py
+++ b/django/geno/billing.py
@@ -329,8 +329,6 @@ def create_monthly_invoices(book, contract, reference_date, invoice_category, op
             ru_list.append(",".join(ru_names) + "; " + building.name)
 
         if factor > 0.0:
-            if not dry_run:
-                logger.info(f"Creating invoices for contract {contract.id} / {invoice_date}")
             if factor != 1.0:
                 factor_txt = " (Faktor %.2f)" % factor
             else:
@@ -346,6 +344,8 @@ def create_monthly_invoices(book, contract, reference_date, invoice_category, op
             ):
                 if not contract.main_contract and not contract.contractors.first():
                     raise InvoiceCreationError("Vertrag hat keine Vertragspartner/Adresse.")
+                if not dry_run:
+                    logger.info(f"Creating invoices for contract {contract.id} / {invoice_date}")
                 billed_months_count += 1
                 if is_additional_invoice:
                     # Add a placeholder invoice for the contract that is billed through
@@ -1870,7 +1870,7 @@ def create_qrbill_rent(
         render = True
 
     address = contract.get_contact_address()
-    if not address.email:
+    if email_template and not address.email:
         # We don't need to continue if there is no email address, since we cannot send
         # the document that would be created here.
         messages = [f"KEIN EMAIL GESENDET! Grund: Keine E-Mail-Adresse für {address} vorhanden."]

--- a/django/geno/views.py
+++ b/django/geno/views.py
@@ -3963,7 +3963,6 @@ class InvoiceManualView(CohivaAdminViewMixin, TemplateView):
             context["s_generic_total"] = nformat(total_amount)
             context["qr_amount"] = total_amount
             context["qr_extra_info"] = "Rechnung %s" % context["invoice_nr"]
-            context["preview"] = dry_run
 
             email_subject = "%s Nr. %s/%s" % (
                 context["betreff"],


### PR DESCRIPTION
- Move `preview` template context variable to `create_qrbill` so it is also available when called by create_qrbill_rent.
- Don't create an rent invoice document if there is no email address to send it to
- Improve the logging of rent invoice and QR-bill creation/sending.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.4.4/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR-bill and invoice handling so failed email delivery and other errors are tracked more reliably.
  * Rent QR-bill creation now stops with a clear error when a contact has no email address, instead of producing an invalid output.
  * Preview-related details are no longer shown in invoice QR-bill output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->