### PR TITLE
Show the 'active' filter consistently at the top in the UI.

### DIFF
--- a/django/credit_accounting/admin.py
+++ b/django/credit_accounting/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from geno.admin import GenoBaseAdmin
+from geno.admin import BooleanFieldDefaultTrueListFilter, GenoBaseAdmin
 
 from .models import Account, AccountOwner, Transaction, UserAccountSetting, Vendor, VendorAdmin
 
@@ -23,7 +23,7 @@ class VendorAdm(GenoBaseAdmin):
     ]
     readonly_fields = ["ts_created", "ts_modified", "links", "backlinks"]
     list_display = ["name", "vendor_type", "active"]
-    list_filter = ["active", "vendor_type"]
+    list_filter = [("active", BooleanFieldDefaultTrueListFilter), "vendor_type"]
     search_fields = ["name", "comment"]
 
 

--- a/django/credit_accounting/admin.py
+++ b/django/credit_accounting/admin.py
@@ -130,6 +130,6 @@ class UserAccountSettingAdmin(GenoBaseAdmin):
     ]
     readonly_fields = ["ts_created", "ts_modified", "links", "backlinks"]
     list_display = ["name", "account", "user", "value"]
-    list_filter = ["name", "active"]
+    list_filter = ["active", "name"]
     search_fields = ["name", "account__name", "comment"]
     autocomplete_fields = ["account", "user"]

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -385,8 +385,8 @@ class AddressAdmin(GenoBaseAdmin):
         "comment",
     ]
     list_filter = [
-        "title",
         ("active", BooleanFieldDefaultTrueListFilter),
+        "title",
         "formal",
         "paymentslip",
         "interest_action",
@@ -608,7 +608,7 @@ class ChildAdmin(GenoBaseAdmin):
     ]
     readonly_fields = ["age", "import_id", "ts_created", "ts_modified", "links", "backlinks"]
     list_display = ["name", "presence", "parents", "age"]
-    list_filter = ["presence", ("name__active", BooleanFieldDefaultTrueListFilter)]
+    list_filter = [("name__active", BooleanFieldDefaultTrueListFilter), "presence"]
     search_fields = ["name__name", "name__first_name", "parents", "notes"]
     autocomplete_fields = ["name"]
 
@@ -654,9 +654,9 @@ class TenantAdmin(GenoBaseAdmin):
     readonly_fields = ["ts_created", "ts_modified", "links", "backlinks"]
     list_display = ["name", "building", "key_number", "active"]
     list_filter = [
-        "building__name",
         ("active", BooleanFieldDefaultTrueListFilter),
         ("building__active", BooleanFieldDefaultTrueListFilter),
+        "building__name",
     ]
     search_fields = ["name__name", "name__first_name", "building__name", "key_number", "notes"]
     autocomplete_fields = ["name", "building"]
@@ -1279,13 +1279,13 @@ class RentalUnitAdmin(GenoBaseAdmin):
         "rentalunit_contracts__contractors__first_name",
     ]
     list_filter = [
+        ("active", BooleanFieldDefaultTrueListFilter),
         "rental_type",
         "rooms",
         "building__name",
         "floor",
         "status",
         "billing_period",
-        ("active", BooleanFieldDefaultTrueListFilter),
     ]
     autocomplete_fields = ["building"]
 
@@ -1862,10 +1862,10 @@ class TenantsViewAdmin(GenoBaseAdmin):
         "p_membership_date",
     ]
     list_filter = [
+        "active",
         "bu_name",
         "ru_type",
         "ru_floor",
-        "active",
         "c_ischild",
         "c_issubcontract",
     ]

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -1862,7 +1862,7 @@ class TenantsViewAdmin(GenoBaseAdmin):
         "p_membership_date",
     ]
     list_filter = [
-        "active",
+        ("active", BooleanFieldDefaultTrueListFilter),
         "bu_name",
         "ru_type",
         "ru_floor",


### PR DESCRIPTION

______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.5.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Reordered administrative filters for a more consistent presentation.
  * Active-status filters now appear first in several administrative views.
  * Some views now default to displaying active records, with options to adjust the filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->