### PR TITLE
Fix odt2pdf: don't allow spaces in the path

### DIFF
--- a/django/geno/utils.py
+++ b/django/geno/utils.py
@@ -27,7 +27,7 @@ def send_info_mail(subject, msg):
 
 
 def odt2pdf(odtfile, instance_tag="default"):
-    tmpdir = "/tmp/odt2pdf_%s_%s" % (settings.GENO_ID, instance_tag)
+    tmpdir = f"/tmp/odt2pdf_{settings.GENO_ID}_{instance_tag}".replace(" ", "")
     soffice_bin = "/usr/lib/libreoffice/program/soffice.bin"
 
     path, basename = os.path.split(odtfile)


### PR DESCRIPTION
Fixes an issue with calling libreoffice with the -env option.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.5.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file path handling during document-to-PDF conversion by removing spaces from generated paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->