### PR TITLE
Fix: Delete import_id when copying objects.

### DIFF
--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -165,6 +165,11 @@ class GenoBase(models.Model):
         return mark_safe(f'<ul class="cohiva_object-actions">{action_list}</ul>')
 
     def save_as_copy(self):
+        """
+        Prepare and save the instance as a new copy.
+        
+        If available, appends "[KOPIE]" to the name and clears the import identifier before saving the instance with a new primary key.
+        """
         if hasattr(self, "name") and isinstance(self.name, str):
             self.name = "%s [KOPIE]" % self.name
         if hasattr(self, "import_id"):
@@ -614,6 +619,9 @@ class Address(GenoBase):
         ]
 
     def save_as_copy(self):
+        """
+        Save the address as a new copy with a new random identifier and no linked user.
+        """
         self.user = None
         self.random_id = uuid.uuid4()
         super().save_as_copy()
@@ -1911,6 +1919,7 @@ class Contract(GenoBase):
         return actions
 
     def save_as_copy(self):
+        """Create a copy of the contract while preserving its related contractors, children, and rental units."""
         old_contractors = self.contractors.all()
         old_children = self.children.all()
         old_rental_units = self.rental_units.all()

--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -167,7 +167,7 @@ class GenoBase(models.Model):
     def save_as_copy(self):
         """
         Prepare and save the instance as a new copy.
-        
+
         If available, appends "[KOPIE]" to the name and clears the import identifier before saving the instance with a new primary key.
         """
         if hasattr(self, "name") and isinstance(self.name, str):
@@ -1118,7 +1118,9 @@ class Share(GenoBase):
         # Effective until date cannot be before effective from date
         if self.effective_from and self.effective_until:
             if self.effective_from > self.effective_until:
-                raise ValidationError(_("Effective until date cannot be before effective from date."))
+                raise ValidationError(
+                    _("Effective until date cannot be before effective from date.")
+                )
         super().clean(*args, **kwargs)
 
     def save(self, *args, **kwargs):
@@ -1959,7 +1961,11 @@ class Contract(GenoBase):
 
     @classmethod
     def get_active_in_period(
-        cls, period_start=None, period_end=None, exclude_period_end=False, include_subcontracts=False
+        cls,
+        period_start=None,
+        period_end=None,
+        exclude_period_end=False,
+        include_subcontracts=False,
     ):
         """Get Contracts that have an overlap with the reference period [period_start, period_end].
         The end date `period_end` is inclusive unless exclude_period_end is set to True.

--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -167,6 +167,8 @@ class GenoBase(models.Model):
     def save_as_copy(self):
         if hasattr(self, "name") and isinstance(self.name, str):
             self.name = "%s [KOPIE]" % self.name
+        if hasattr(self, "import_id"):
+            self.import_id = None
         self.pk = None
         self.id = None
         self._state.adding = True
@@ -613,7 +615,6 @@ class Address(GenoBase):
 
     def save_as_copy(self):
         self.user = None
-        self.import_id = None
         self.random_id = uuid.uuid4()
         super().save_as_copy()
 
@@ -1913,7 +1914,6 @@ class Contract(GenoBase):
         old_contractors = self.contractors.all()
         old_children = self.children.all()
         old_rental_units = self.rental_units.all()
-        self.import_id = None
         super().save_as_copy()
         self.contractors.set(old_contractors)
         self.children.set(old_children)

--- a/django/geno/tests/test_models.py
+++ b/django/geno/tests/test_models.py
@@ -2,12 +2,24 @@ from datetime import date
 from unittest.mock import patch
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.test import TestCase, override_settings
 from django.urls import NoReverseMatch, reverse
 
-from geno.models import Address, Contract, InvoiceCategory, Member, RegistrationEvent
+from geno.models import (
+    Address,
+    Building,
+    Child,
+    Contract,
+    InvoiceCategory,
+    Member,
+    RegistrationEvent,
+    RentalUnit,
+    Share,
+    ShareType,
+)
 
 from .base import GenoAdminTestCase
 
@@ -414,3 +426,132 @@ class GetActiveContractsTests(GenoAdminTestCase):
         result = list(Contract.get_active_in_period(period_start=self.D3, period_end=self.D4))
         self.assertNotIn(first, result)
         self.assertIn(second, result)
+
+
+class GenoBaseSaveAsCopyTests(TestCase):
+    """
+    Tests for GenoBase.save_as_copy(), in particular the clearing of
+    `import_id` (if the model has that field) that was added alongside
+    the pre-existing `name` "[KOPIE]" suffix logic.
+    """
+
+    def test_import_id_and_name_are_reset_on_copy(self):
+        building = Building.objects.create(name="Building A")
+        rental_unit = RentalUnit.objects.create(
+            name="A1",
+            rental_type="Wohnung",
+            building=building,
+            import_id="IMPORT-100",
+        )
+        original_pk = rental_unit.pk
+
+        rental_unit.save_as_copy()
+
+        # The instance now represents the freshly inserted copy.
+        self.assertIsNotNone(rental_unit.pk)
+        self.assertNotEqual(rental_unit.pk, original_pk)
+        self.assertEqual(rental_unit.name, "A1 [KOPIE]")
+        self.assertIsNone(rental_unit.import_id)
+
+        # The original row must be left untouched.
+        original = RentalUnit.objects.get(pk=original_pk)
+        self.assertEqual(original.name, "A1")
+        self.assertEqual(original.import_id, "IMPORT-100")
+
+        # The copy was persisted with a cleared import_id.
+        copy = RentalUnit.objects.get(pk=rental_unit.pk)
+        self.assertIsNone(copy.import_id)
+        self.assertEqual(copy.name, "A1 [KOPIE]")
+
+    def test_import_id_cleared_even_when_name_is_not_a_string(self):
+        # Child.name is a OneToOneField to Address (not a string), so the
+        # "[KOPIE]" suffix logic must not touch it, but import_id must
+        # still be cleared independently.
+        address = Address.objects.create(name="Test", first_name="Testus")
+        share = Share.objects.create(
+            name=address,
+            share_type=ShareType.objects.create(name="Test"),
+            value=1,
+            import_id="SHARE-1",
+        )
+
+        share.save_as_copy()
+
+        self.assertEqual(share.name, address)
+        self.assertIsNone(share.import_id)
+
+
+class AddressSaveAsCopyTests(TestCase):
+    def test_save_as_copy_clears_user_random_id_and_import_id(self):
+        user = User.objects.create_user(username="hans", password="secret")
+        address = Address.objects.create(
+            name="Muster",
+            first_name="Hans",
+            user=user,
+            import_id="ADDR-1",
+        )
+        original_pk = address.pk
+        original_random_id = address.random_id
+
+        address.save_as_copy()
+
+        self.assertIsNotNone(address.pk)
+        self.assertNotEqual(address.pk, original_pk)
+        self.assertIsNone(address.user)
+        self.assertNotEqual(address.random_id, original_random_id)
+        self.assertIsNone(address.import_id)
+        self.assertEqual(address.name, "Muster [KOPIE]")
+
+        # The original row keeps its user, random_id and import_id.
+        original = Address.objects.get(pk=original_pk)
+        self.assertEqual(original.user, user)
+        self.assertEqual(original.random_id, original_random_id)
+        self.assertEqual(original.import_id, "ADDR-1")
+        self.assertEqual(original.name, "Muster")
+
+    def test_save_as_copy_without_import_id_still_clears_user_and_random_id(self):
+        user = User.objects.create_user(username="anna", password="secret")
+        address = Address.objects.create(name="Musterfrau", first_name="Anna", user=user)
+        original_random_id = address.random_id
+
+        address.save_as_copy()
+
+        self.assertIsNone(address.user)
+        self.assertIsNone(address.import_id)
+        self.assertNotEqual(address.random_id, original_random_id)
+
+
+class ContractSaveAsCopyTests(TestCase):
+    def setUp(self):
+        building = Building.objects.create(name="Building C")
+        self.rental_unit = RentalUnit.objects.create(
+            name="C1", rental_type="Wohnung", building=building
+        )
+        self.contractor = Address.objects.create(name="Muster", first_name="Hans")
+        child_address = Address.objects.create(name="Muster", first_name="Kind")
+        self.child = Child.objects.create(name=child_address, presence=5.0)
+
+    def test_save_as_copy_preserves_m2m_and_clears_import_id(self):
+        contract = Contract.objects.create(date=date(2024, 1, 1), import_id="CONTRACT-1")
+        contract.contractors.set([self.contractor])
+        contract.children.set([self.child])
+        contract.rental_units.set([self.rental_unit])
+
+        original_pk = contract.pk
+
+        contract.save_as_copy()
+
+        self.assertIsNotNone(contract.pk)
+        self.assertNotEqual(contract.pk, original_pk)
+        self.assertIsNone(contract.import_id)
+        self.assertEqual(list(contract.contractors.all()), [self.contractor])
+        self.assertEqual(list(contract.children.all()), [self.child])
+        self.assertEqual(list(contract.rental_units.all()), [self.rental_unit])
+
+        # The original contract is unaffected and keeps its import_id and
+        # its own M2M relations.
+        original = Contract.objects.get(pk=original_pk)
+        self.assertEqual(original.import_id, "CONTRACT-1")
+        self.assertEqual(list(original.contractors.all()), [self.contractor])
+        self.assertEqual(list(original.children.all()), [self.child])
+        self.assertEqual(list(original.rental_units.all()), [self.rental_unit])

--- a/django/pyproject.toml
+++ b/django/pyproject.toml
@@ -27,6 +27,7 @@ lint.ignore = [
   "E722",    # Do not use bare `except`
   "E731",    # Do not assign a `lambda` expression, use a `def`
   "UP031",   # Use format specifiers instead of percent format
+  "UP037",   # Remove quotes from type annotation (currently, we need that to avoid circular imports...)
   "B904",    # raise-without-from-inside-except
   "SIM108",  # if-else-block-instead-of-if-exp
   "SIM115",  # open-file-with-context-handler


### PR DESCRIPTION
Fixes issues with DB constraints when saving objects that have an import_id as a copy.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.5.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copied records now correctly clear their import identifier, preventing them from being treated as the original imported record.
  * Address copies reset their associated user and generate a new identifier.
  * Contract copies preserve linked contractors, children, and rental units while receiving a cleared import identifier.
  * Copied records retain their original data and receive an appropriate copy name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->