### PR TITLE
COHIV-326: Regenerate invoices (single and in bulk with mailing wizard)

### DIFF
--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -1709,6 +1709,7 @@ class InvoiceAdmin(GenoBaseAdmin):
         ("contract", "year", "month"),
         "is_additional_invoice",
         "active",
+        "object_actions",
         ("transaction_id", "reference_nr"),
         "additional_info",
         ("fin_transaction_ref", "fin_account", "fin_account_receivables"),
@@ -1719,6 +1720,7 @@ class InvoiceAdmin(GenoBaseAdmin):
     ]
     readonly_fields = [
         "consolidated",
+        "object_actions",
         "transaction_id",
         "reference_nr",
         "additional_info",

--- a/django/geno/documents.py
+++ b/django/geno/documents.py
@@ -28,6 +28,7 @@ from geno.models import (
     Document,
     DocumentType,
     GenericAttribute,
+    Invoice,
     InvoiceCategory,
     Member,
     MemberAttribute,
@@ -106,7 +107,6 @@ class DocumentTemplate:
         self.update_context_options()
         self.dry_run = dry_run
         self.temp_files = []
-        self.regenerate_from_invoice = None
 
     def __str__(self):
         return str(self.content_template)
@@ -122,13 +122,9 @@ class DocumentTemplate:
                 else:
                     self.context_options[opt_type.name] = opt.value
 
-    def get_context(self, recipient):
-        ctx = {"qr_account": None}
+    def get_context(self, recipient, regenerate_from_invoice):
+        ctx = {"qr_account": None, "regenerate_from_invoice": regenerate_from_invoice}
         ctx.update(recipient.address.get_context())
-        ## HACK!!
-        if self.regenerate_from_invoice:
-            ctx["datum"] = self.regenerate_from_invoice.date.strftime("%d.%m.%Y")
-            ctx["jahr"] = self.regenerate_from_invoice.date.strftime("%Y")
         if self.context_options["billing_context"]:
             ctx.update(self.get_billing_context(recipient))
         if self.context_options["share_statement_context"]:
@@ -270,8 +266,10 @@ class DocumentTemplate:
                     f"Rechnungs-Typ {self.context_options['qrbill_invoice_type_id']} nicht gefunden!"
                 )
             if ctx["bill_amount"]:
-                if self.regenerate_from_invoice:
-                    invoice_id = self.regenerate_from_invoice.id
+                if ctx["regenerate_from_invoice"]:
+                    invoice_id = ctx["regenerate_from_invoice"].id
+                    ctx["datum"] = ctx["regenerate_from_invoice"].date.strftime("%d.%m.%Y")
+                    ctx["jahr"] = ctx["regenerate_from_invoice"].date.strftime("%Y")
                 elif not self.dry_run:
                     ctx["invoice"] = self.do_invoice_accounting(recipient, ctx, invoice_category)
                     invoice_id = ctx["invoice"].id
@@ -351,14 +349,14 @@ class DocumentTemplate:
         logger.info(f"   > Added Invoice object: {invoice}")
         return invoice
 
-    def render(self, recipient):
+    def render(self, recipient, regenerate_from_invoice=None):
         output = RenderedDocument()
         output.file = self.content_template.file.path
         filename_tag = sanitize_filename(
             self.content_template.name
         )  # use template name as filename tag
         if self.content_template.template_type == "OpenDocument":
-            ctx = self.get_context(recipient)
+            ctx = self.get_context(recipient, regenerate_from_invoice)
             logger.info(
                 " > fill template %s with context: anrede=%s, name=%s, vorname=%s, org=%s"
                 % (
@@ -432,6 +430,7 @@ class Recipient:
         self.skip_reason = None
         self.content_object = None
         self.documents = []
+        self.invoices = []
         self.log = []
         self.warning = False
         self.failure = False
@@ -455,6 +454,22 @@ class Recipient:
                 self.warning = True
                 self.log.append("WARNUNG: Ungewöhnliche PLZ/Adressierung -> Adresse im Ausland?")
 
+    def add_invoices(self, regenerate_mode, invoice_ids):
+        if not regenerate_mode or not invoice_ids:
+            return
+        query = Invoice.objects.filter(id__in=invoice_ids)
+        if regenerate_mode == "latests":
+            query = query.order_by("-date").first()
+        elif regenerate_mode == "oldest":
+            query = query.order_by("date").first()
+        elif regenerate_mode != "all":
+            raise ValueError(f"Invalid regenerate_mode: {regenerate_mode}")
+        for invoice in query:
+            self.add_invoice(invoice)
+
+    def add_invoice(self, invoice):
+        self.invoices.append(invoice)
+
 
 class ProcessDocuments:
     def __init__(self, dry_run=False):
@@ -464,6 +479,8 @@ class ProcessDocuments:
         self.zipfile_ob = None
         self.output_format = None
         self.templates = []
+        self.invoice_template = None
+        self.regenerate_invoices_mode = None
         self.recipients = []
         self.contexts = {}
         self.test_email_address = None
@@ -479,6 +496,9 @@ class ProcessDocuments:
 
     def set_output_format(self, filetype):
         self.output_format = filetype
+
+    def set_regenerate_invoices_mode(self, mode):
+        self.regenerate_invoices_mode = mode
 
     def add_document_template(self, att):
         try:
@@ -513,6 +533,37 @@ class ProcessDocuments:
             )
         )
 
+    def set_invoice_template(self, att):
+        if not self.regenerate_invoices_mode:
+            return
+        try:
+            (att_type, att_id) = att.split(":", 1)
+        except ValueError:
+            att_type = None
+            att_id = None
+
+        content_template = None
+        doctype = None
+        if att_type == "DocumentType":
+            try:
+                doctype = DocumentType.objects.get(id=att_id)
+                content_template = doctype.template
+            except DocumentType.DoesNotExist:
+                raise ValueError(f"Dokumenttyp mit ID {att_id} nicht gefunden.")
+        elif att_type == "ContentTemplate":
+            try:
+                content_template = ContentTemplate.objects.get(id=att_id)
+            except ContentTemplate.DoesNotExist:
+                raise ValueError(f"Vorlage mit ID {att_id} nicht gefunden.")
+        else:
+            raise TypeError(f"Unbekannter Vorlagentyp: {att}")
+        self.invoice_template = DocumentTemplate(
+            content_template,
+            doctype=doctype,
+            output_format=self.output_format,
+            dry_run=self.dry_run,
+        )
+
     def add_recipient(self, member_or_address, contract=None, extra_info=None):
         if isinstance(member_or_address, Member):
             recip = Recipient(
@@ -527,6 +578,7 @@ class ProcessDocuments:
             raise TypeError(f"{member_or_address} must be Member or Address.")
         self.validate_recipient(recip)
         self.recipients.append(recip)
+        return recip
 
     def validate_recipient(self, recipient):
         if self.mail_template and not recipient.address.email:
@@ -557,6 +609,21 @@ class ProcessDocuments:
                     )
                     recipient.skip_reason = e
                     break
+
+    def regenerate_invoices(self):
+        if not self.regenerate_invoices_mode:
+            return
+        logger.info("Regenerating invoices.")
+        for recipient in self.recipients:
+            if recipient.skip_reason:
+                logger.info(f"Skipping {recipient}: {recipient.skip_reason}")
+                continue
+            logger.info(f"Regenerate invoices for {recipient}")
+            for invoice in recipient.invoices:
+                invoice_doc = self.invoice_template.render(recipient, invoice)
+                if not invoice_doc:
+                    raise RuntimeError(f"Konnte Rechnung nicht erstellen: {invoice}")
+                recipient.documents.append(invoice_doc)
 
     def send_output(self):
         if self.mail_template:
@@ -816,6 +883,7 @@ def send_member_mail_process(data):
         process.set_output_format("odt")
     elif data["template_files"]:
         process.set_output_format("pdf")
+    process.set_regenerate_invoices_mode(data.get("regenerate_invoices"))
 
     try:
         for template in data["template_files"]:
@@ -823,19 +891,29 @@ def send_member_mail_process(data):
     except Exception as e:
         return {"errors": [{"info": f"Fehler: Konte Dokumentvorlage nicht hinzufügen: {e}"}]}
 
+    try:
+        process.set_invoice_template(data.get("invoice_template"))
+    except Exception as e:
+        return {"errors": [{"info": f"Fehler: Konte Rechnungsvorlage nicht hinzufügen: {e}"}]}
+
     for m in data["members"]:
         if "contract_id" in m:
             contract = Contract.objects.get(id=m["contract_id"])
         else:
             contract = None
         if m["member_type"] == "member":
-            recip = Member.objects.get(pk=m["id"])
+            obj = Member.objects.get(pk=m["id"])
         else:
-            recip = Address.objects.get(pk=m["id"])
-        process.add_recipient(recip, contract, m["extra_info"])
+            obj = Address.objects.get(pk=m["id"])
+        recip = process.add_recipient(obj, contract, m["extra_info"])
+        try:
+            recip.add_invoices(process.regenerate_invoices_mode, m.get("invoice_ids"))
+        except Exception as e:
+            return {"errors": [{"info": f"Fehler: Konte Rechnungen nicht hinzufügen: {e}"}]}
 
     try:
         process.generate_documents()
+        process.regenerate_invoices()
     except Exception as e:
         logger.error(f"Fehler beim Erstellen der Dokumente: {e}")
         return {"errors": [{"info": f"Fehler beim Erstellen der Dokumente: {e}"}]}

--- a/django/geno/documents.py
+++ b/django/geno/documents.py
@@ -359,9 +359,6 @@ class DocumentTemplate:
         )  # use template name as filename tag
         if self.content_template.template_type == "OpenDocument":
             ctx = self.get_context(recipient)
-            ## Hack!!!
-            if self.regenerate_from_invoice:
-                print(ctx)
             logger.info(
                 " > fill template %s with context: anrede=%s, name=%s, vorname=%s, org=%s"
                 % (

--- a/django/geno/documents.py
+++ b/django/geno/documents.py
@@ -504,30 +504,7 @@ class ProcessDocuments:
     def set_regenerate_invoices_mode(self, mode):
         self.regenerate_invoices_mode = mode
 
-    def add_document_template(self, att):
-        try:
-            (att_type, att_id) = att.split(":", 1)
-        except ValueError:
-            att_type = None
-            att_id = None
-
-        content_template = None
-        doctype = None
-        if att_type == "DocumentType":
-            try:
-                doctype = DocumentType.objects.get(id=att_id)
-                content_template = doctype.templates.filter(active=True).first()
-                if not content_template:
-                    raise ValueError(f"Dokumenttyp {doctype} hat keine Vorlagen-Datei")
-            except DocumentType.DoesNotExist:
-                raise ValueError(f"Dokumenttyp mit ID {att_id} nicht gefunden.")
-        elif att_type == "ContentTemplate":
-            try:
-                content_template = ContentTemplate.objects.get(id=att_id)
-            except ContentTemplate.DoesNotExist:
-                raise ValueError(f"Vorlage mit ID {att_id} nicht gefunden.")
-        else:
-            raise TypeError(f"Unbekannter Vorlagentyp: {att}")
+    def add_document_template(self, content_template, doctype=None):
         self.templates.append(
             DocumentTemplate(
                 content_template,
@@ -537,30 +514,9 @@ class ProcessDocuments:
             )
         )
 
-    def set_invoice_template(self, att):
+    def set_invoice_template(self, content_template, doctype=None):
         if not self.regenerate_invoices_mode:
             return
-        try:
-            (att_type, att_id) = att.split(":", 1)
-        except ValueError:
-            att_type = None
-            att_id = None
-
-        content_template = None
-        doctype = None
-        if att_type == "DocumentType":
-            try:
-                doctype = DocumentType.objects.get(id=att_id)
-                content_template = doctype.template
-            except DocumentType.DoesNotExist:
-                raise ValueError(f"Dokumenttyp mit ID {att_id} nicht gefunden.")
-        elif att_type == "ContentTemplate":
-            try:
-                content_template = ContentTemplate.objects.get(id=att_id)
-            except ContentTemplate.DoesNotExist:
-                raise ValueError(f"Vorlage mit ID {att_id} nicht gefunden.")
-        else:
-            raise TypeError(f"Unbekannter Vorlagentyp: {att}")
         self.invoice_template = DocumentTemplate(
             content_template,
             doctype=doctype,
@@ -893,12 +849,14 @@ def send_member_mail_process(data):
 
     try:
         for template in data["template_files"]:
-            process.add_document_template(template)
+            process.add_document_template(ContentTemplate.get_by_formfield_key(template))
     except Exception as e:
         return {"errors": [{"info": f"Fehler: Konte Dokumentvorlage nicht hinzufügen: {e}"}]}
 
     try:
-        process.set_invoice_template(data.get("invoice_template"))
+        process.set_invoice_template(
+            ContentTemplate.get_by_formfield_key(data.get("invoice_template"))
+        )
     except Exception as e:
         return {"errors": [{"info": f"Fehler: Konte Rechnungsvorlage nicht hinzufügen: {e}"}]}
 

--- a/django/geno/documents.py
+++ b/django/geno/documents.py
@@ -106,6 +106,7 @@ class DocumentTemplate:
         self.update_context_options()
         self.dry_run = dry_run
         self.temp_files = []
+        self.regenerate_from_invoice = None
 
     def __str__(self):
         return str(self.content_template)
@@ -124,6 +125,10 @@ class DocumentTemplate:
     def get_context(self, recipient):
         ctx = {"qr_account": None}
         ctx.update(recipient.address.get_context())
+        ## HACK!!
+        if self.regenerate_from_invoice:
+            ctx["datum"] = self.regenerate_from_invoice.date.strftime("%d.%m.%Y")
+            ctx["jahr"] = self.regenerate_from_invoice.date.strftime("%Y")
         if self.context_options["billing_context"]:
             ctx.update(self.get_billing_context(recipient))
         if self.context_options["share_statement_context"]:
@@ -265,7 +270,9 @@ class DocumentTemplate:
                     f"Rechnungs-Typ {self.context_options['qrbill_invoice_type_id']} nicht gefunden!"
                 )
             if ctx["bill_amount"]:
-                if not self.dry_run:
+                if self.regenerate_from_invoice:
+                    invoice_id = self.regenerate_from_invoice.id
+                elif not self.dry_run:
                     ctx["invoice"] = self.do_invoice_accounting(recipient, ctx, invoice_category)
                     invoice_id = ctx["invoice"].id
                 else:
@@ -352,6 +359,9 @@ class DocumentTemplate:
         )  # use template name as filename tag
         if self.content_template.template_type == "OpenDocument":
             ctx = self.get_context(recipient)
+            ## Hack!!!
+            if self.regenerate_from_invoice:
+                print(ctx)
             logger.info(
                 " > fill template %s with context: anrede=%s, name=%s, vorname=%s, org=%s"
                 % (

--- a/django/geno/documents.py
+++ b/django/geno/documents.py
@@ -349,12 +349,13 @@ class DocumentTemplate:
         logger.info(f"   > Added Invoice object: {invoice}")
         return invoice
 
-    def render(self, recipient, regenerate_from_invoice=None):
+    def render(self, recipient, regenerate_from_invoice=None, filename_tag=None):
         output = RenderedDocument()
         output.file = self.content_template.file.path
-        filename_tag = sanitize_filename(
-            self.content_template.name
-        )  # use template name as filename tag
+        if filename_tag is None:
+            filename_tag = sanitize_filename(
+                self.content_template.name
+            )  # use template name as filename tag
         if self.content_template.template_type == "OpenDocument":
             ctx = self.get_context(recipient, regenerate_from_invoice)
             logger.info(
@@ -458,14 +459,17 @@ class Recipient:
         if not regenerate_mode or not invoice_ids:
             return
         query = Invoice.objects.filter(id__in=invoice_ids)
-        if regenerate_mode == "latests":
-            query = query.order_by("-date").first()
+        if regenerate_mode == "latest":
+            self.add_invoice(query.order_by("-date").first())
+            return
         elif regenerate_mode == "oldest":
-            query = query.order_by("date").first()
-        elif regenerate_mode != "all":
-            raise ValueError(f"Invalid regenerate_mode: {regenerate_mode}")
-        for invoice in query:
-            self.add_invoice(invoice)
+            self.add_invoice(query.order_by("date").first())
+            return
+        elif regenerate_mode == "all":
+            for invoice in query:
+                self.add_invoice(invoice)
+            return
+        raise ValueError(f"Invalid regenerate_mode: {regenerate_mode}")
 
     def add_invoice(self, invoice):
         self.invoices.append(invoice)
@@ -560,7 +564,7 @@ class ProcessDocuments:
         self.invoice_template = DocumentTemplate(
             content_template,
             doctype=doctype,
-            output_format=self.output_format,
+            output_format="pdf",
             dry_run=self.dry_run,
         )
 
@@ -620,7 +624,8 @@ class ProcessDocuments:
                 continue
             logger.info(f"Regenerate invoices for {recipient}")
             for invoice in recipient.invoices:
-                invoice_doc = self.invoice_template.render(recipient, invoice)
+                filename_tag = f"Rechnung_{invoice.id}"
+                invoice_doc = self.invoice_template.render(recipient, invoice, filename_tag)
                 if not invoice_doc:
                     raise RuntimeError(f"Konnte Rechnung nicht erstellen: {invoice}")
                 recipient.documents.append(invoice_doc)
@@ -883,7 +888,8 @@ def send_member_mail_process(data):
         process.set_output_format("odt")
     elif data["template_files"]:
         process.set_output_format("pdf")
-    process.set_regenerate_invoices_mode(data.get("regenerate_invoices"))
+    if data.get("regenerate_invoices"):
+        process.set_regenerate_invoices_mode(data.get("regenerate_invoices_mode"))
 
     try:
         for template in data["template_files"]:

--- a/django/geno/forms.py
+++ b/django/geno/forms.py
@@ -715,7 +715,7 @@ class MemberMailActionForm(forms.Form):
         ("latest", _("Nur die letzte (jüngste) Rechnung der Person")),
         ("oldest", _("Nur die älteste Rechnung der Person")),
     )
-    regenerate_invoices_mode = forms.MultipleChoiceField(
+    regenerate_invoices_mode = forms.ChoiceField(
         choices=regenerate_invoices_mode_choices,
         label=_(
             "Welche der mit dem Filter in Schritt 1 ausgewählten Rechnungen "

--- a/django/geno/forms.py
+++ b/django/geno/forms.py
@@ -529,7 +529,14 @@ class MemberMailSelectForm(forms.Form):
         choices = []
         for m in members:
             if m["id"] and m["member"]:
-                choices.append((m["id"], m["member"]))
+                label = m["member"]
+                if "invoice_ids" in m:
+                    count = len(m["invoice_ids"])
+                    if count == 1:
+                        label += " (1 Rechnung)"
+                    else:
+                        label += f" ({count} Rechnungen)"
+                choices.append((m["id"], label))
         self.fields["select_members"] = forms.MultipleChoiceField(
             choices=choices,
             label=_("Empfänger auswählen"),
@@ -581,6 +588,14 @@ class MemberMailActionForm(forms.Form):
             help_text=_("Tippen um zu suchen, mehrere Einträge möglich"),
         )
 
+        self.fields["invoice_template"] = forms.ChoiceField(
+            choices=choices,
+            label=_("Rechnungsvorlage für die erneut erzeugten Rechnungen"),
+            widget=UnfoldAdminSelect2Widget(),
+            required=False,
+            help_text=_("Tippen um zu suchen, mehrere Einträge möglich"),
+        )
+
         template_mail_choices = []
         try:
             for template in (
@@ -604,19 +619,35 @@ class MemberMailActionForm(forms.Form):
         self.helper.form_class = ""
         self.helper.layout = Layout(
             Div("action", css_class="mb-4"),
-            UnfoldSeparator(),
-            UnfoldSectionHeading(_("Dokumente")),
-            Div("template_files", css_class="mb-4"),
-            UnfoldSeparator(),
-            UnfoldSectionHeading(_("E-Mail")),
-            Div("send_email", css_class="mb-4"),
             ConditionalDiv(
-                "email-settings",
+                "document-block",
+                UnfoldSeparator(),
+                UnfoldSectionHeading(_("Dokumente")),
+                Div("template_files", css_class="mb-4"),
+                Div("regenerate_invoices", css_class="mb-4"),
+                ConditionalDiv(
+                    "regenerate-invoices-settings",
+                    Div("regenerate_invoices_mode", css_class="mb-4"),
+                    Div("invoice_template", css_class="mb-4"),
+                ),
+            ),
+            ConditionalDiv(
+                "email-block",
+                UnfoldSeparator(),
+                UnfoldSectionHeading(_("E-Mail")),
+                # Div("send_email", css_class="mb-4"),
+                # ConditionalDiv(
+                #    "email-settings",
+                #    Div("template_mail", css_class="mb-4"),
+                #    Div("subject", css_class="mb-4"),
+                #    Div("email_sender", css_class="mb-4"),
+                #    Div("email_copy", css_class="mb-4"),
+                #    initial_display="none",
+                # ),
                 Div("template_mail", css_class="mb-4"),
                 Div("subject", css_class="mb-4"),
                 Div("email_sender", css_class="mb-4"),
                 Div("email_copy", css_class="mb-4"),
-                initial_display="none",
             ),
             UnfoldSeparator(),
             UnfoldSectionHeading(_("Attribute ändern")),
@@ -674,11 +705,31 @@ class MemberMailActionForm(forms.Form):
         widget=UnfoldAdminSelectWidget(),
     )
 
-    send_email = forms.BooleanField(
-        label=_("E-Mail versenden"),
+    regenerate_invoices = forms.BooleanField(
+        label=_("Rechnungen nochmals erzeugen (ohne erneute Buchung)"),
         required=False,
         widget=UnfoldBooleanSwitchWidget(),
     )
+    regenerate_invoices_mode_choices = (
+        ("all", _("Alle Rechnugen der Person")),
+        ("latest", _("Nur die letzte (jüngste) Rechnung der Person")),
+        ("oldest", _("Nur die älteste Rechnung der Person")),
+    )
+    regenerate_invoices_mode = forms.MultipleChoiceField(
+        choices=regenerate_invoices_mode_choices,
+        label=_(
+            "Welche der mit dem Filter in Schritt 1 ausgewählten Rechnungen "
+            "sollen jeweils nochmals erzugt werden?"
+        ),
+        widget=UnfoldAdminSelectWidget(),
+        required=False,
+    )
+
+    # send_email = forms.BooleanField(
+    #    label=_("E-Mail versenden"),
+    #    required=False,
+    #    widget=UnfoldBooleanSwitchWidget(),
+    # )
 
     subject = forms.CharField(
         label=_("Betreff"),

--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -2100,6 +2100,7 @@ class Invoice(GenoBase):
 
     @property
     def content_template(self):
+        ## HACK!
         return "ContentTemplate:36"
 
     def get_object_actions(self):
@@ -2113,24 +2114,25 @@ class Invoice(GenoBase):
             ]
         return None
 
-    def regenerate_invoice_document(self):
+    def regenerate_invoice_document(self, template=None):
         from geno.documents import ProcessDocuments
 
-        # data["template_files"] = ...
-        template = self.content_template
+        ## HACK!
+        if not template:
+            template = self.content_template
 
         process = ProcessDocuments(dry_run=True)
         process.set_output_format("pdf")
-        process.add_document_template(template)
-        ## HACK!
-        process.templates[0].regenerate_from_invoice = self
+        process.set_regenerate_invoices_mode("all")
+        process.set_invoice_template(template)
         try:
             member = Member.objects.get(name=self.person)
             process.add_recipient(member, None, "")
         except Member.DoesNotExist:
-            process.add_recipient(self.person, self.contract, "")
+            recip = process.add_recipient(self.person, self.contract, "")
+            recip.add_invoice(self)
         try:
-            process.generate_documents()
+            process.regenerate_invoices()
         except Exception as e:
             logger.error(f"Fehler beim Erstellen der Dokumente: {e}")
             return None

--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -2098,6 +2098,78 @@ class Invoice(GenoBase):
             namestr = "%s" % self.contract
         return "%s/%s %s CHF %.2f" % (namestr, self.name, self.invoice_type, self.amount)
 
+    @property
+    def content_template(self):
+        return "ContentTemplate:36"
+
+    def get_object_actions(self):
+        ## HACK!
+        if self.invoice_type == "Invoice" and self.invoice_category.name == "Mitgliedschaft":
+            return [
+                (
+                    "/geno/invoice/regenerate/%s/" % self.pk,
+                    "Rechnung nochmals erzeugen (PDF)",
+                ),
+            ]
+        return None
+
+    def regenerate_invoice_document(self):
+        from geno.documents import ProcessDocuments
+        # data["template_files"] = ...
+        template = self.content_template
+
+        process = ProcessDocuments(dry_run=True)
+        process.set_output_format("pdf")
+        process.add_document_template(template)
+        ## HACK!
+        process.templates[0].regenerate_from_invoice=self
+        try:
+            member = Member.objects.get(name=self.person)
+            process.add_recipient(member, None, "")
+        except Member.DoesNotExist:
+            process.add_recipient(self.person, self.contract, "")
+        try:
+            process.generate_documents()
+        except Exception as e:
+            logger.error(f"Fehler beim Erstellen der Dokumente: {e}")
+            return None
+
+        output_doc = process.recipients[0].documents[0]
+        #process.cleanup()
+        return output_doc
+
+    #        self.content_template = None
+    #        self.doctype = None
+    #        template = DocumentTemplate(
+    #                    self.content_template,
+    #                    self.doctype=doctype,
+    #                    output_format="odt",
+    #                    dry_run=True,
+    #                   )
+    #
+    #        if self.person:
+    #            address = self.person
+    #        else:
+    #            return None
+    #        ctx = self.get_context(address)
+    #        #content_template_file_path = invoice.content_template
+    #        content_template_file_path = ""
+    #        output_file = fill_template_pod(
+    #            content_template_file_path, ctx, output_format="odt"
+    #        )
+    #        output_filename = (
+    #            f"{address.get_filename_str()}_{filename_tag}.odt"
+    #        )
+    #        if ctx["qr_account"]:
+    #            render_qrbill(
+    #                None,
+    #                ctx,
+    #                output.filename,
+    #                base_pdf_file=output.file,
+    #                append_pdf_file=None,
+    #                output_dir=output_dir,
+    #            )
+
     class Meta:
         verbose_name = "Rechnung"
         verbose_name_plural = "Rechnungen"

--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -2100,12 +2100,42 @@ class Invoice(GenoBase):
 
     @property
     def content_template(self):
-        ## HACK!
-        return "ContentTemplate:36"
+        ## TODO: We need a more robust way for remembering the content_template for invoices.
+        ##       Options:
+        ##         - Link the ContentTemplate to Inovice when creating the invoice. But this
+        ##           would not work for generic invoices, because we also need the full context.
+        ##         - Link a Document to Inovice when creating the invoice, the Document then
+        ##           links to ContentTemplate and also stores the full context.
+        ##         - In addition, the Invoice (oder Document) could also store the generated PDF
+        ##           so we would have the option to either re-generate or simply get the PDF again.
+
+        ## Try to get the most recent active ContentTemplate for this invoice category:
+        template = (
+            ContentTemplate.objects.filter(active=True)
+            .filter(template_context__name__name="qrbill_invoice_type_id")
+            .filter(template_context__value=str(self.invoice_category.reference_id))
+            .distinct()
+            .order_by("-ts_modified")
+            .first()
+        )
+        if template:
+            return template
+
+        ## Use generic template for the invoice doctype, if available
+        ## TODO: This does not work yet, since the context to regenerate a generic invoice
+        ##       is not available (see above).
+        # try:
+        #    invoice_doctype = DocumentType.objects.get(name="invoice", active=True)
+        #    template = invoice_doctype.template
+        #    # template = invoice_doctype.templates.filter(active=True).first()
+        #    return template
+        # except DocumentType.DoesNotExist:
+        #    return None
+
+        return None
 
     def get_object_actions(self):
-        ## HACK!
-        if self.invoice_type == "Invoice" and self.invoice_category.name == "Mitgliedschaft":
+        if self.invoice_type == "Invoice" and self.content_template:
             return [
                 (
                     "/geno/invoice/regenerate/%s/" % self.pk,
@@ -2117,9 +2147,11 @@ class Invoice(GenoBase):
     def regenerate_invoice_document(self, template=None):
         from geno.documents import ProcessDocuments
 
-        ## HACK!
         if not template:
             template = self.content_template
+        if not template:
+            logger.error(f"No content_template available to regenerate the invoice {self.id}.")
+            return None
 
         process = ProcessDocuments(dry_run=True)
         process.set_output_format("pdf")
@@ -2127,10 +2159,10 @@ class Invoice(GenoBase):
         process.set_invoice_template(template)
         try:
             member = Member.objects.get(name=self.person)
-            process.add_recipient(member, None, "")
+            recip = process.add_recipient(member, self.contract, "")
         except Member.DoesNotExist:
             recip = process.add_recipient(self.person, self.contract, "")
-            recip.add_invoice(self)
+        recip.add_invoice(self)
         try:
             process.regenerate_invoices()
         except Exception as e:
@@ -2140,38 +2172,6 @@ class Invoice(GenoBase):
         output_doc = process.recipients[0].documents[0]
         # process.cleanup()
         return output_doc
-
-    #        self.content_template = None
-    #        self.doctype = None
-    #        template = DocumentTemplate(
-    #                    self.content_template,
-    #                    self.doctype=doctype,
-    #                    output_format="odt",
-    #                    dry_run=True,
-    #                   )
-    #
-    #        if self.person:
-    #            address = self.person
-    #        else:
-    #            return None
-    #        ctx = self.get_context(address)
-    #        #content_template_file_path = invoice.content_template
-    #        content_template_file_path = ""
-    #        output_file = fill_template_pod(
-    #            content_template_file_path, ctx, output_format="odt"
-    #        )
-    #        output_filename = (
-    #            f"{address.get_filename_str()}_{filename_tag}.odt"
-    #        )
-    #        if ctx["qr_account"]:
-    #            render_qrbill(
-    #                None,
-    #                ctx,
-    #                output.filename,
-    #                base_pdf_file=output.file,
-    #                append_pdf_file=None,
-    #                output_dir=output_dir,
-    #            )
 
     class Meta:
         verbose_name = "Rechnung"
@@ -2323,6 +2323,39 @@ class ContentTemplate(GenoBase):
             return Template(self.text)
         else:
             return None
+
+    @classmethod
+    def get_by_formfield_key(cls, key: str) -> "ContentTemplate|None":
+        """Returns the ContentTemplate object specified by a key that typically comes from a
+        form submission and has the following format: "<key_type>:<object_id>".
+        The following key_types are currently supported:
+          - DocumentType
+          - ContentTemplate
+        """
+        try:
+            (key_type, object_id) = key.split(":", 1)
+        except ValueError:
+            key_type = None
+            object_id = None
+
+        content_template = None
+        doctype = None
+        if key_type == "DocumentType":
+            try:
+                doctype = DocumentType.objects.get(id=object_id, active=True)
+                content_template = doctype.templates.filter(active=True).first()
+                if not content_template:
+                    raise ValueError(f"Dokumenttyp {doctype} hat keine Vorlagen-Datei")
+            except DocumentType.DoesNotExist:
+                raise ValueError(f"Dokumenttyp mit ID {object_id} nicht gefunden.")
+        elif key_type == "ContentTemplate":
+            try:
+                content_template = cls.objects.get(id=object_id, active=True)
+            except cls.DoesNotExist:
+                raise ValueError(f"Vorlage mit ID {object_id} nicht gefunden.")
+        else:
+            raise TypeError(f"Unbekannter Vorlagentyp: {key}")
+        return content_template
 
     def save_as_copy(self):
         old_template_context = self.template_context.all()

--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -2115,6 +2115,7 @@ class Invoice(GenoBase):
 
     def regenerate_invoice_document(self):
         from geno.documents import ProcessDocuments
+
         # data["template_files"] = ...
         template = self.content_template
 
@@ -2122,7 +2123,7 @@ class Invoice(GenoBase):
         process.set_output_format("pdf")
         process.add_document_template(template)
         ## HACK!
-        process.templates[0].regenerate_from_invoice=self
+        process.templates[0].regenerate_from_invoice = self
         try:
             member = Member.objects.get(name=self.person)
             process.add_recipient(member, None, "")
@@ -2135,7 +2136,7 @@ class Invoice(GenoBase):
             return None
 
         output_doc = process.recipients[0].documents[0]
-        #process.cleanup()
+        # process.cleanup()
         return output_doc
 
     #        self.content_template = None

--- a/django/geno/templates/geno/member_send_mail.html
+++ b/django/geno/templates/geno/member_send_mail.html
@@ -213,7 +213,46 @@
               }
           }
 
+          // Show/hide conditional fields based on action selection
+          function toggleAction() {
+              const action = document.getElementById('id_action');
+              if (!action) return;
+
+              const documentBlock = document.getElementById('document-block');
+              const emailBlock = document.getElementById('email-block');
+
+              const value = action.value;
+
+              // Hide all by default
+              if (documentBlock) documentBlock.style.display = 'none';
+              if (emailBlock) emailBlock.style.display = 'none';
+
+              // Show relevant elements
+              if ((value === 'makezip' || value === 'makezip_pdf' || value === 'mail' || value === 'mail_test') && documentBlock) {
+                  documentBlock.style.display = 'block';
+              }
+              if ((value === 'mail' || value === 'mail_test') && emailBlock) {
+                  emailBlock.style.display = 'block';
+              }
+          }
+
           // Show/hide email settings based on send_email checkbox
+          function toggleRegenerateInvoiceSettings() {
+              console.log("1");
+              const regenerateInvoice = document.getElementById('id_regenerate_invoices');
+              const regenerateInvoiceSettings = document.getElementById('regenerate-invoices-settings');
+
+              if (!regenerateInvoice || !regenerateInvoiceSettings) return;
+
+              if (regenerateInvoice.checked) {
+                  regenerateInvoiceSettings.style.display = 'block';
+              } else {
+                  regenerateInvoiceSettings.style.display = 'none';
+              }
+          }
+
+          // Show/hide email settings based on send_email checkbox
+          /*
           function toggleEmailSettings() {
               const sendEmail = document.getElementById('id_send_email');
               const emailSettings = document.getElementById('email-settings');
@@ -225,7 +264,7 @@
               } else {
                   emailSettings.style.display = 'none';
               }
-          }
+          }*/
 
           // Show/hide attribute settings based on change_attributes checkbox
           function toggleAttributeSettings() {
@@ -245,7 +284,9 @@
           document.addEventListener('DOMContentLoaded', function() {
               toggleFilters();
               toggleInvoiceFilters();
-              toggleEmailSettings();
+              toggleAction();
+              //toggleEmailSettings();
+              toggleRegenerateInvoiceSettings();
               toggleAttributeSettings();
 
               // Add event listeners
@@ -259,10 +300,20 @@
                   filterInvoice.addEventListener('change', toggleInvoiceFilters);
               }
 
-              const sendEmail = document.getElementById('id_send_email');
+              const selectAction = document.getElementById('id_action');
+              if (selectAction) {
+                  selectAction.addEventListener('change', toggleAction);
+              }
+
+              const regenerateInvoice = document.getElementById('id_regenerate_invoices');
+              if (regenerateInvoice) {
+                  regenerateInvoice.addEventListener('change', toggleRegenerateInvoiceSettings);
+              }
+
+              /*const sendEmail = document.getElementById('id_send_email');
               if (sendEmail) {
                   sendEmail.addEventListener('change', toggleEmailSettings);
-              }
+              }*/
 
               const changeAttributes = document.getElementById('id_change_attributes');
               if (changeAttributes) {

--- a/django/geno/urls.py
+++ b/django/geno/urls.py
@@ -116,6 +116,11 @@ urlpatterns = [
         geno_views.InvoiceBatchGenerateView.as_view(action="download"),
         name="invoice-download",
     ),
+    re_path(
+        r"^invoice/regenerate/(?P<key>[0-9]+)/?$",
+        geno_views.InvoiceRegenerateView.as_view(),
+        name="invoice-regenerate",
+    ),
     path("debtor/", geno_views.DebtorView.as_view(action="overview"), name="debtor-list"),
     re_path(
         r"^debtor/detail/(?P<key_type>[cp])/(?P<key>[0-9]+)/?$",

--- a/django/geno/views.py
+++ b/django/geno/views.py
@@ -4160,17 +4160,31 @@ class InvoiceBatchGenerateView(DryRunActionView):
 
 
 class InvoiceRegenerateView(CohivaAdminViewMixin, TemplateView):
-    title = "Mietobjektespiegel"
+    title = "Rechnung neu erstellen"
     permission_required = ("geno.invoice", "geno.transaction_invoice")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "response": [{"variant": "error", "info": self.error_msg}],
+            }
+        )
+        return context
 
     def get(self, *args, **kwargs):
         invoice = Invoice.objects.get(pk=kwargs["key"])
-        output = invoice.regenerate_invoice_document()
-        print(output)
-        pdf_file = open(output.file, "rb")
-        resp = FileResponse(pdf_file, content_type="application/pdf")
-        resp["Content-Disposition"] = "attachment; filename=%s" % output.filename
-        return resp
+        logger.info(f"Regenerating invoice {invoice.id}")
+        try:
+            output = invoice.regenerate_invoice_document()
+            pdf_file = open(output.file, "rb")
+            resp = FileResponse(pdf_file, content_type="application/pdf")
+            resp["Content-Disposition"] = "attachment; filename=%s" % output.filename
+            return resp
+        except Exception as e:
+            logger.error(f"Could not create PDF for invoice {invoice.id}: {e}")
+            self.error_msg = f'Konnte PDF für Rechnung "{invoice}" nicht erstellen: {e}'
+            return super().get(*args, **kwargs)
 
 
 class ResidentUnitListView(CohivaAdminViewMixin, TemplateView):

--- a/django/geno/views.py
+++ b/django/geno/views.py
@@ -3171,6 +3171,8 @@ def send_member_mail_filter_by_invoice(form, member_list):
         if query.count():
             if form.cleaned_data["filter_invoice"] == "exclude":
                 member["id"] = None  # exclude
+            else:
+                member["invoice_ids"] = list(query.values_list("id", flat=True))
         else:
             if form.cleaned_data["filter_invoice"] == "include":
                 member["id"] = None  # exclude

--- a/django/geno/views.py
+++ b/django/geno/views.py
@@ -4159,6 +4159,20 @@ class InvoiceBatchGenerateView(DryRunActionView):
         return ret
 
 
+class InvoiceRegenerateView(CohivaAdminViewMixin, TemplateView):
+    title = "Mietobjektespiegel"
+    permission_required = ("geno.invoice", "geno.transaction_invoice")
+
+    def get(self, *args, **kwargs):
+        invoice = Invoice.objects.get(pk=kwargs["key"])
+        output = invoice.regenerate_invoice_document()
+        print(output)
+        pdf_file = open(output.file, "rb")
+        resp = FileResponse(pdf_file, content_type="application/pdf")
+        resp["Content-Disposition"] = "attachment; filename=%s" % output.filename
+        return resp
+
+
 class ResidentUnitListView(CohivaAdminViewMixin, TemplateView):
     title = "Mietobjektespiegel"
     permission_required = "geno.rental_objects"


### PR DESCRIPTION
- Add an object action to Invoices to regenerate the invoice document.
- The ContentTemplate required for that is selected by searching the templates for those that reference the same QR-bill reference_id as the invoice (not a robust approach).
- Extend the mail wizard form to enable regeneration of invoices in bulk.
- Improve the form logic (hide/show fields) of the mailing wizard in step 3.

TODO:
- Make the ContentTemplate selection more robust.
- Add support for generic invoices that are not created by the mailing wizard with a specific ContentTemplate.
- Adjust and extend tests.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.5.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
