### PR TITLE
Fix: Migrate existing doctype templates; add migration tests.

### DIFF
--- a/django/cohiva/settings_for_tests.py
+++ b/django/cohiva/settings_for_tests.py
@@ -37,7 +37,7 @@ logging.disable()
 if os.getenv("SKIP_SLOW", "false") == "true":
     ## Speed up tests in quick mode
     PASSWORD_HASHERS = ("django.contrib.auth.hashers.MD5PasswordHasher",)
-    if os.getenv("KEEP_DB", "false") == "false":
+    if os.getenv("MIGRATION_TESTS", "false") == "false" and os.getenv("KEEP_DB", "false") == "false":
         ## Skip migrations and use a test runner that applies selected migrations needed for tests
         DATABASES["default"]["TEST"] = {"MIGRATE": False}
         TEST_RUNNER = "cohiva.utils.migrations_for_tests.SelectiveMigrationRunner"

--- a/django/geno/migrations/0006_tenantsview.py
+++ b/django/geno/migrations/0006_tenantsview.py
@@ -10,7 +10,8 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            """CREATE VIEW geno_TenantsView AS
+            """DROP VIEW IF EXISTS geno_TenantsView;
+CREATE VIEW geno_TenantsView AS
 SELECT DISTINCT
 	CONVERT(concat(LPAD(c.id, 4, 0), LPAD(bu.id, 4, 0), LPAD(ru.id, 4, 0), LPAD(ad.id, 4,0)), INTEGER) as id,
 	'' as comment,
@@ -106,6 +107,6 @@ LEFT JOIN
     geno_address ad ON ad.id = ch.name_id
 LEFT JOIN
     geno_member m ON m.name_id = ad.id;""",
-            """DROP VIEW geno_TenantsView;""",
+            """DROP VIEW IF EXISTS geno_TenantsView;""",
         )
     ]

--- a/django/geno/migrations/0027_alter_documenttype_template_to_m2m.py
+++ b/django/geno/migrations/0027_alter_documenttype_template_to_m2m.py
@@ -4,16 +4,30 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 
+def migrate_template(apps, schema_editor):
+    doctype_model = apps.get_model("geno", "DocumentType")
+
+    for obj in doctype_model.objects.all():
+        if obj.template:
+            obj.templates.add(obj.template)
+
+
+def migrate_template_reverse(apps, schema_editor):
+    doctype_model = apps.get_model("geno", "DocumentType")
+
+    for obj in doctype_model.objects.all():
+        template = obj.templates.first()
+        if template:
+            obj.template = template
+            obj.save(update_fields=["template"])
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("geno", "0026_convert_uuids_from_char"),
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name="documenttype",
-            name="template",
-        ),
         migrations.AddField(
             model_name="document",
             name="template",
@@ -36,5 +50,10 @@ class Migration(migrations.Migration):
                 to="geno.contenttemplate",
                 verbose_name="Vorlagen",
             ),
+        ),
+        migrations.RunPython(migrate_template, migrate_template_reverse),
+        migrations.RemoveField(
+            model_name="documenttype",
+            name="template",
         ),
     ]

--- a/django/geno/migrations/0030_rename_and_add_share_fields.py
+++ b/django/geno/migrations/0030_rename_and_add_share_fields.py
@@ -20,13 +20,23 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="share",
             name="effective_from",
-            field=models.DateField(blank=True, default=None, null=True, verbose_name="Wirksam ab"),
+            field=models.DateField(
+                blank=True,
+                default=None,
+                help_text="Leer lassen, falls identisch mit Zahlungsdatum. Wird für Reporting/Zinsberechnung verwendet.",
+                null=True,
+                verbose_name="Wirksam ab",
+            ),
         ),
         migrations.AddField(
             model_name="share",
             name="effective_until",
             field=models.DateField(
-                blank=True, default=None, null=True, verbose_name="Wirksam bis"
+                blank=True,
+                default=None,
+                help_text="Leer lassen, falls identisch mit Rückzahlungsdatum.",
+                null=True,
+                verbose_name="Wirksam bis",
             ),
         ),
         migrations.RemoveField(model_name="share", name="state"),

--- a/django/geno/migrations/0031_tenantsview_active.py
+++ b/django/geno/migrations/0031_tenantsview_active.py
@@ -107,7 +107,103 @@ LEFT JOIN
     geno_address ad ON ad.id = ch.name_id
 LEFT JOIN
     geno_member m ON m.name_id = ad.id;""",
-            """DROP VIEW geno_TenantsView;""",
+            """DROP VIEW IF EXISTS geno_TenantsView;
+CREATE VIEW geno_TenantsView AS
+SELECT DISTINCT
+	CONVERT(concat(LPAD(c.id, 4, 0), LPAD(bu.id, 4, 0), LPAD(ru.id, 4, 0), LPAD(ad.id, 4,0)), INTEGER) as id,
+	'' as comment,
+    bu.name as bu_name,
+    ru.name as ru_name,
+    ru.rental_type as ru_type,
+    ru.label as ru_label,
+    ru.floor as ru_floor,
+    ru.area as ru_area,
+    ru.rooms as ru_rooms,
+    ad.organization as organization,
+    ad.name as ad_name,
+    ad.first_name as ad_first_name,
+    ad.title as ad_title,
+    ad.email as ad_email,
+    0 as c_ischild,
+    NULL as c_age,
+    NULL as presence,
+    ad.date_birth as ad_date_birth,
+    concat(ad.city_zipcode, ' ', ad.city_name) as ad_city,
+    concat(ad.street_name, ' ', ad.house_number) as ad_street,
+    ad.telephone as ad_tel1,
+    ad.mobile as ad_tel2,
+    ad.hometown as p_hometown,
+    ad.occupation as p_occupation,
+    m.date_join as p_membership_date,
+    bu.id as building_id,
+    ru.id as rental_unit_id,
+    c.isSC as c_isSubcontract,
+    c.id as contract_id,
+    c.ts_created,
+    c.ts_modified
+FROM
+    (select ctmp.id as id, ctmp.ts_created as ts_created, ctmp.ts_modified as ts_modified, 0 as isSC from geno_contract ctmp UNION select sctmp.id as id, sctmp.ts_created as ts_created, sctmp.ts_modified as ts_modified, 1 as isSC from geno_contract ctmp JOIN geno_contract sctmp ON ctmp.id = sctmp.main_contract_id) as c
+LEFT JOIN
+    geno_contract_rental_units cru ON cru.contract_id = c.id
+LEFT JOIN
+    geno_rentalunit ru ON ru.id = cru.rentalunit_id
+LEFT JOIN
+    geno_building bu ON bu.id = ru.building_id
+LEFT JOIN
+    geno_contract_contractors ccon ON ccon.contract_id = c.id
+LEFT JOIN
+    geno_address ad ON ccon.address_id = ad.id
+LEFT JOIN
+    geno_member m ON m.name_id = ad.id
+UNION
+SELECT DISTINCT
+	CONVERT(concat(LPAD(c.id, 4, 0), LPAD(bu.id, 4, 0), LPAD(ru.id, 4, 0), LPAD(ad.id, 4,0)), INTEGER) as id,
+	'' as comment,
+    bu.name as bu_name,
+    ru.name as ru_name,
+    ru.rental_type as ru_type,
+    ru.label as ru_label,
+    ru.floor as ru_floor,
+    ru.area as ru_area,
+    ru.rooms as ru_rooms,
+    ad.organization as organization,
+    ad.name as ad_name,
+    ad.first_name as ad_first_name,
+    ad.title as ad_title,
+    ad.email as ad_email,
+    1 as c_ischild,
+    TIMESTAMPDIFF(YEAR, ad.date_birth, CURDATE()) as c_age,
+    ch.presence as presence,
+    ad.date_birth as ad_date_birth,
+    concat(ad.city_zipcode, ' ', ad.city_name) as ad_city,
+    concat(ad.street_name, ' ', ad.house_number) as ad_street,
+    ad.telephone as ad_tel1,
+    ad.mobile as ad_tel2,
+    ad.hometown as p_hometown,
+    ad.occupation as p_occupation,
+    m.date_join as p_membership_date,
+    bu.id as building_id,
+    ru.id as rental_unit_id,
+    c.isSC as c_isSubcontract,
+    c.id as contract_id,
+    c.ts_created,
+    c.ts_modified
+FROM
+    (select ctmp.id as id, ctmp.ts_created as ts_created, ctmp.ts_modified as ts_modified, 0 as isSC from geno_contract ctmp UNION select sctmp.id as id, sctmp.ts_created as ts_created, sctmp.ts_modified as ts_modified,  1 as isSC from geno_contract ctmp JOIN geno_contract sctmp ON ctmp.id = sctmp.main_contract_id) as c
+LEFT JOIN
+    geno_contract_rental_units cru ON cru.contract_id = c.id
+LEFT JOIN
+    geno_rentalunit ru ON ru.id = cru.rentalunit_id
+LEFT JOIN
+    geno_building bu ON bu.id = ru.building_id
+JOIN
+    geno_contract_children cc ON cc.contract_id = c.id
+LEFT JOIN
+    geno_child ch ON cc.child_id = ch.id
+LEFT JOIN
+    geno_address ad ON ad.id = ch.name_id
+LEFT JOIN
+    geno_member m ON m.name_id = ad.id;""",
         ),
         migrations.AddField(
             model_name="tenantsview",

--- a/django/geno/tests/test_migrations.py
+++ b/django/geno/tests/test_migrations.py
@@ -1,0 +1,40 @@
+from django_test_migrations.contrib.unittest_case import MigratorTestCase
+
+
+class TestMigration0027(MigratorTestCase):
+    migrate_from = ("geno", "0026_convert_uuids_from_char")
+    migrate_to = ("geno", "0027_alter_documenttype_template_to_m2m")
+
+    def prepare(self):
+        """Prepare some data before the migration."""
+        template_model = self.old_state.apps.get_model("geno", "ContentTemplate")
+        doctype_model = self.old_state.apps.get_model("geno", "DocumentType")
+        template = template_model.objects.create(name="Test-template")
+        doctype_model.objects.create(name="test", template=template)
+
+    def test_migration(self):
+        """Verify that existing templates are migrated."""
+        doctype = self.new_state.apps.get_model("geno", "DocumentType")
+        obj = doctype.objects.get(name="test")
+        self.assertEqual(obj.templates.count(), 1)
+        self.assertEqual(obj.templates.first().name, "Test-template")
+
+
+class TestMigration0027Reverse(MigratorTestCase):
+    migrate_to = ("geno", "0026_convert_uuids_from_char")
+    migrate_from = ("geno", "0027_alter_documenttype_template_to_m2m")
+
+    def prepare(self):
+        """Prepare some data before the migration."""
+        template_model = self.old_state.apps.get_model("geno", "ContentTemplate")
+        doctype_model = self.old_state.apps.get_model("geno", "DocumentType")
+        template1 = template_model.objects.create(name="Test-template1")
+        template2 = template_model.objects.create(name="Test-template2")
+        doctype = doctype_model.objects.create(name="test-reverse")
+        doctype.templates.set([template1, template2])
+
+    def test_migration(self):
+        """Verify that existing templates are migrated (reverse)."""
+        doctype_model = self.new_state.apps.get_model("geno", "DocumentType")
+        obj = doctype_model.objects.get(name="test-reverse")
+        self.assertEqual(obj.template.name, "Test-template1")

--- a/django/requirements-docker.txt
+++ b/django/requirements-docker.txt
@@ -153,6 +153,8 @@ django-taggit==6.1.0
     # via wagtail
 django-tasks==0.7.0
     # via wagtail
+django-test-migrations==1.5.0
+    # via -r requirements.in
 django-treebeard==4.7.1
     # via wagtail
 django-unfold==0.78.1
@@ -360,6 +362,7 @@ typing-extensions==4.13.2
     #   aiosignal
     #   django-stubs-ext
     #   django-tasks
+    #   django-test-migrations
     #   jwcrypto
 tzdata==2025.2
     # via

--- a/django/requirements.in
+++ b/django/requirements.in
@@ -93,6 +93,7 @@ whitenoise
 
 ## For tests
 coverage
+django-test-migrations
 
 ## For development
 ruff

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -163,6 +163,8 @@ django-taggit==6.1.0
     # via wagtail
 django-tasks==0.7.0
     # via wagtail
+django-test-migrations==1.5.0
+    # via -r requirements.in
 django-treebeard==4.7.1
     # via wagtail
 django-unfold==0.78.1
@@ -404,6 +406,7 @@ typing-extensions==4.13.2
     #   aiosignal
     #   django-stubs-ext
     #   django-tasks
+    #   django-test-migrations
     #   jwcrypto
 tzdata==2025.2
     # via

--- a/django/run-tests.sh
+++ b/django/run-tests.sh
@@ -31,7 +31,7 @@ export PYTHONWARNINGS=always
 INSTALL_DIR=$(grep "^INSTALL_DIR = " cohiva/base_config.py | cut -d \" -f 2)
 
 ## Normalize flags
-case "${COVERAGE,,}" in
+case "${COVERAGE}" in
   true|1|yes|on)
     COVERAGE="true"
     ;;
@@ -39,7 +39,7 @@ case "${COVERAGE,,}" in
     COVERAGE="false"
     ;;
 esac
-case "${GITHUB_ACTIONS,,}" in
+case "${GITHUB_ACTIONS}" in
   true|1|yes|on)
     GITHUB_ACTIONS="true"
     ;;
@@ -47,7 +47,7 @@ case "${GITHUB_ACTIONS,,}" in
     GITHUB_ACTIONS="false"
     ;;
 esac
-case "${SKIP_SLOW,,}" in
+case "${SKIP_SLOW}" in
   true|1|yes|on)
     SKIP_SLOW="true"
     ;;
@@ -55,7 +55,7 @@ case "${SKIP_SLOW,,}" in
     SKIP_SLOW="false"
     ;;
 esac
-case "${MIGRATION_TESTS,,}" in
+case "${MIGRATION_TESTS}" in
   true|1|yes|on)
     MIGRATION_TESTS="true"
     ;;
@@ -63,7 +63,7 @@ case "${MIGRATION_TESTS,,}" in
     MIGRATION_TESTS="false"
     ;;
 esac
-case "${KEEP_DB,,}" in
+case "${KEEP_DB}" in
   true|1|yes|on)
     KEEP_DB="true"
     ;;

--- a/django/run-tests.sh
+++ b/django/run-tests.sh
@@ -10,7 +10,7 @@
 #
 #    COVERAGE=1              # Run with coverage.
 #    SKIP_SLOW=1             # Skip slow tests and migrations.
-#    MIGRAION_TESTS = 1      # Include also migration tests.
+#    MIGRATION_TESTS = 1     # Include also migration tests.
 #    KEEP_DB=1               # Keep the test database between test runs to speed up startup.
 #    SELECTED_TESTS="<list>" # Only run the test(s) specified in the list.
 #

--- a/django/run-tests.sh
+++ b/django/run-tests.sh
@@ -5,21 +5,18 @@
 # Usage:
 #    ./run-tests.sh
 #
-# By default, all tests are run. You can set the following environment variables
-# to modify the test run:
+# By default, all tests except migration tests are run. No coverage analysis is done.
+# You can set the following environment variables to modify the test run:
 #
-#    COVERAGE=1   # Run with coverage
-#    SKIP_SLOW=1  # Skip slow tests and migrations
-#    KEEP_DB=1    # Keep the test database between test runs to speed up startup
+#    COVERAGE=1              # Run with coverage.
+#    SKIP_SLOW=1             # Skip slow tests and migrations.
+#    MIGRAION_TESTS = 1      # Include also migration tests.
+#    KEEP_DB=1               # Keep the test database between test runs to speed up startup.
+#    SELECTED_TESTS="<list>" # Only run the test(s) specified in the list.
 #
 # Example for running quick (repeated) tests:
 #
 #    SKIP_SLOW=1 KEEP_DB=1 ./run-tests.sh
-#
-# Further customization can be done by modifying the variables in this script:
-#
-#   SELECTED_TESTS - to run only selected tests
-#   TEST_OPTS      - to add options to the test runner
 #
 
 # exit on error
@@ -58,6 +55,14 @@ case "${SKIP_SLOW,,}" in
     SKIP_SLOW="false"
     ;;
 esac
+case "${MIGRATION_TESTS,,}" in
+  true|1|yes|on)
+    MIGRATION_TESTS="true"
+    ;;
+  *)
+    MIGRATION_TESTS="false"
+    ;;
+esac
 case "${KEEP_DB,,}" in
   true|1|yes|on)
     KEEP_DB="true"
@@ -80,11 +85,13 @@ fi
 
 ## Base test command
 TESTCMD="./manage.py test --settings=cohiva.settings_for_tests"
+
+# Skip slow/migration tests
 if [ "$SKIP_SLOW" = "true" ] ; then
     TESTCMD="${TESTCMD} --exclude-tag=slow-test"
-    export PYTHONDONTWRITEBYTECODE=1
-    export SKIP_SLOW
-    export KEEP_DB
+fi
+if [ "$MIGRATION_TESTS" = "false" ] ; then
+    TESTCMD="${TESTCMD} --exclude-tag=migration_test"
 fi
 
 ## Test options
@@ -94,8 +101,13 @@ else
   TEST_OPTS=""
 fi
 
-## Select test to run (leave emtpy to run all tests)
-SELECTED_TESTS=""
+export SKIP_SLOW
+export MIGRATION_TESTS
+export KEEP_DB
+
+SELECTED_TESTS=${SELECTED_TESTS:-}
+
+## Select test to run (leave commented/emtpy to run all tests)
 # Examples:
 #SELECTED_TESTS="cohiva.tests credit_accounting.tests finance.tests geno.tests importer.tests portal.tests report.tests reservation.tests"
 #SELECTED_TESTS="geno.tests.test_models.AddressTest finance.tests.test_accounting.TransactionTestCase.test_strings"


### PR DESCRIPTION
- Migrate existing templates when changing the DocumentType data model.
- Make the TenantsView migration reversible.
- Add migration tests (disabled by default because they are slow).
- Add help_text to Share model migration.
______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.5.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Document types can now use multiple templates.
  - Documents can specify an individual template.

- **Bug Fixes**
  - Improved tenant view recreation and cleanup.
  - Updated tenant view data handling during migrations.
  - Added guidance for share date fields.

- **Tests**
  - Added coverage for template migration and rollback behavior.
  - Improved migration test execution, selection, and default exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->