### PR TITLE
Add ShareBuildingFilter and improve XLS export.

### DIFF
--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -104,7 +104,7 @@ class ShareBuildingFilter(admin.SimpleListFilter):
        RentalUnit in the selected Building.
      Note that attached_to_building and attached_to_contract are mutually exclusive."""
 
-    title = Building._meta.verbose_name  # .title()
+    title = Building._meta.verbose_name
     parameter_name = "building_id"
 
     def lookups(self, request, model_admin):
@@ -131,7 +131,7 @@ class ShareBuildingFilter(admin.SimpleListFilter):
                 & Q(attached_to_contract__isnull=True)
                 & Exists(contract_subquery)
             )
-        )
+        ).distinct()
 
 
 class BooleanFieldDefaultTrueListFilter(admin.BooleanFieldListFilter):

--- a/django/geno/admin.py
+++ b/django/geno/admin.py
@@ -10,7 +10,7 @@ from django.contrib import admin, messages
 from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import Group, User
-from django.db.models import Case, IntegerField, Q, Value, When
+from django.db.models import Case, Exists, IntegerField, OuterRef, Q, Value, When
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -92,6 +92,46 @@ class ShareStateFilter(admin.SimpleListFilter):
         elif value == "gefordert":
             return queryset.filter(Q(payment_date__gt=today) | Q(payment_date__isnull=True))
         return queryset
+
+
+class ShareBuildingFilter(admin.SimpleListFilter):
+    """Filter Shares to show the ones that are related to a specific building.
+    The relationship is determined by the following rules:
+     - If attached_to_building is set, include the Share if that building is the selected Building.
+     - If attached_to_contract is set, include the Share if the contract has a RentalUnit in the
+       selected Building.
+     - Otherwise, include the Share if the owner of the share has an active Contract with a
+       RentalUnit in the selected Building.
+     Note that attached_to_building and attached_to_contract are mutually exclusive."""
+
+    title = Building._meta.verbose_name  # .title()
+    parameter_name = "building_id"
+
+    def lookups(self, request, model_admin):
+        return Building.objects.filter(active=True).values_list("pk", "name")
+
+    def queryset(self, request, queryset):
+        building_id = self.value()
+        if building_id is None:
+            return queryset
+        try:
+            building = Building.objects.get(id=building_id)
+        except Building.DoesNotExist:
+            return queryset.none()
+        # Subquery for active contracts that include the Address of the Share (`name` field) in
+        # the list of contractors and that are related to the building.
+        contract_subquery = Contract.get_active().filter(
+            contractors=OuterRef("name"), rental_units__building=building
+        )
+        return queryset.filter(
+            Q(attached_to_building=building)
+            | Q(attached_to_contract__rental_units__building=building)
+            | (
+                Q(attached_to_building__isnull=True)
+                & Q(attached_to_contract__isnull=True)
+                & Exists(contract_subquery)
+            )
+        )
 
 
 class BooleanFieldDefaultTrueListFilter(admin.BooleanFieldListFilter):
@@ -902,6 +942,7 @@ class ShareAdmin(ObjectActionsMixin, GenoBaseAdmin):
         ("value", "value_total", "is_interest_credit", "is_pension_fund", "is_business"),
         "attached_to_contract",
         "attached_to_building",
+        "related_contracts",
         "note",
         ("interest", "interest_mode", "manual_interest"),
         ("identifier", "identifier_external"),
@@ -914,6 +955,7 @@ class ShareAdmin(ObjectActionsMixin, GenoBaseAdmin):
     readonly_fields = [
         "payment_state",
         "value_total",
+        "related_contracts",
         "interest",
         "import_id",
         "active",
@@ -945,6 +987,7 @@ class ShareAdmin(ObjectActionsMixin, GenoBaseAdmin):
         "is_interest_credit",
         "is_pension_fund",
         "is_business",
+        ShareBuildingFilter,
         "payment_date",
         "repayment_date",
         "duration",

--- a/django/geno/exporter.py
+++ b/django/geno/exporter.py
@@ -247,14 +247,16 @@ class ExportXlsMixin:
                 for field_list in fieldset[1]["fields"]:
                     if isinstance(field_list, str):
                         field_list = (field_list,)
-                    for field in field_list:
-                        if field not in self.export_exclude_fields:
-                            fields.append(field)
-                            header[field] = label_for_field(field, self.model, model_admin=self)
+                    for field_name in field_list:
+                        if field_name not in self.export_exclude_fields:
+                            fields.append(field_name)
+                            header[field_name] = label_for_field(
+                                field_name, self.model, model_admin=self
+                            )
         else:
             ## Export all model fields, but no calculated values.
             for field in meta.fields:
-                if field not in self.export_exclude_fields:
+                if field.name not in self.export_exclude_fields:
                     fields.append(field.name)
                     header[field.name] = field.verbose_name
         return export_to_xls_generic(queryset, fields, str(meta), header, str(meta))

--- a/django/geno/exporter.py
+++ b/django/geno/exporter.py
@@ -7,9 +7,11 @@ import vdirsyncer
 import vobject
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.admin.utils import label_for_field
 from django.http import HttpResponse
 from django.template import loader
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from openpyxl import load_workbook
 from vdirsyncer.storage.dav import CardDAVStorage
 
@@ -187,7 +189,12 @@ def export_to_xls_generic(data, fields, title, header, filename_suffix):
         col_num = 0
         for field in fields:
             c = ws.cell(row=row_num + 1, column=col_num + 1)
-            value = getattr(obj, field, "")
+            try:
+                value = getattr(obj, field, "")
+                if callable(value):
+                    value = value()
+            except:
+                value = _("[invalid]")
             if isinstance(value, numbers.Number):
                 c.value = value
             else:
@@ -216,14 +223,40 @@ def export_to_xls_generic(data, fields, title, header, filename_suffix):
 
 
 class ExportXlsMixin:
+    """Mixin class that adds an action to export all fields shown in the ModelAdmin an XLS file.
+
+    If `export_use_fieldset` is `True`, all model fields, as well as calculated values,
+    that are configured in the model admin are exported. Otherwise, all the model fields are
+    exported, regardless of the model admin configuration (but no calculated values).
+
+    Fields with names listed in `export_exclude_fields` are excluded from the export.
+    """
+
+    export_use_fieldset = True
+    export_exclude_fields = ["links", "backlinks"]
+
     @admin.display(description="Ausgewählte als XLS exportieren")
     def export_as_xls(self, request, queryset):
         fields = []
         header = {}
         meta = self.model._meta
-        for field in meta.fields:
-            fields.append(field.name)
-            header[field.name] = field.verbose_name
+        if self.export_use_fieldset:
+            # Export model fields, as well as calculated values, that are configured
+            # in the model admin
+            for fieldset in self.get_fieldsets(request):
+                for field_list in fieldset[1]["fields"]:
+                    if isinstance(field_list, str):
+                        field_list = (field_list,)
+                    for field in field_list:
+                        if field not in self.export_exclude_fields:
+                            fields.append(field)
+                            header[field] = label_for_field(field, self.model, model_admin=self)
+        else:
+            ## Export all model fields, but no calculated values.
+            for field in meta.fields:
+                if field not in self.export_exclude_fields:
+                    fields.append(field.name)
+                    header[field.name] = field.verbose_name
         return export_to_xls_generic(queryset, fields, str(meta), header, str(meta))
 
 

--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -1089,15 +1089,13 @@ class Share(GenoBase):
     @admin.display(description=_("Related building/contracts"))
     def related_contracts(self) -> str:
         def _format(contracts: list[Contract]):
-            return ", ".join(
-                [
-                    (
-                        f"{c.get_building_label()}: "
-                        f"{c.list_rental_units(without_building=True, exclude_minor=True)}"
-                    )
-                    for c in contracts
-                ]
-            )
+            ret = []
+            for c in contracts:
+                for building, rental_units in c.list_rental_units(
+                    group_buildings=True, exclude_minor=True
+                ).items():
+                    ret.append(f"{building}: {rental_units}")
+            return ", ".join(ret)
 
         if self.attached_to_contract:
             return _format([self.attached_to_contract])
@@ -1941,23 +1939,36 @@ class Contract(GenoBase):
         return ru.building.name if ru else None
 
     def list_rental_units(
-        self, short=False, exclude_minor=False, as_list=False, without_building=False
-    ):
+        self, short=False, exclude_minor=False, as_list=False, group_buildings=False
+    ) -> str | list[str] | dict[str, str | list[str]]:
         units = []
+        units_by_building = {}
         if exclude_minor:
             rus = self.rental_units.exclude(rental_type="Kellerabteil")
         else:
             rus = self.rental_units.all()
         for u in rus.order_by("name"):
             if short:
-                units.append("%s" % u.name)
-            elif without_building:
-                units.append(u.name_with_label)
+                label = str(u.name)
+            elif group_buildings:
+                label = str(u.name_with_label)
             else:
-                units.append("%s" % u)
+                label = str(u)
+            units.append(label)
+            if u.building.name in units_by_building:
+                units_by_building[u.building.name].append(label)
+            else:
+                units_by_building[u.building.name] = [label]
         if as_list:
+            if group_buildings:
+                return units_by_building
             return units
         else:
+            if group_buildings:
+                ret = {}
+                for building, building_units in units_by_building.items():
+                    ret[building] = "/".join(building_units)
+                return ret
             return "/".join(units)
 
     def get_context(self):

--- a/django/geno/models.py
+++ b/django/geno/models.py
@@ -1085,6 +1085,26 @@ class Share(GenoBase):
             return self.repayment_date
         return None
 
+    @property
+    @admin.display(description=_("Related building/contracts"))
+    def related_contracts(self) -> str:
+        def _format(contracts: list[Contract]):
+            return ", ".join(
+                [
+                    (
+                        f"{c.get_building_label()}: "
+                        f"{c.list_rental_units(without_building=True, exclude_minor=True)}"
+                    )
+                    for c in contracts
+                ]
+            )
+
+        if self.attached_to_contract:
+            return _format([self.attached_to_contract])
+        if self.attached_to_building:
+            return self.attached_to_building.name
+        return _format(list(Contract.get_active().filter(contractors=self.name)))
+
     def __str__(self):
         extra_info = self.share_type
         if self.payment_state:
@@ -1920,7 +1940,9 @@ class Contract(GenoBase):
         ru = self.rental_units.first()
         return ru.building.name if ru else None
 
-    def list_rental_units(self, short=False, exclude_minor=False, as_list=False):
+    def list_rental_units(
+        self, short=False, exclude_minor=False, as_list=False, without_building=False
+    ):
         units = []
         if exclude_minor:
             rus = self.rental_units.exclude(rental_type="Kellerabteil")
@@ -1929,6 +1951,8 @@ class Contract(GenoBase):
         for u in rus.order_by("name"):
             if short:
                 units.append("%s" % u.name)
+            elif without_building:
+                units.append(u.name_with_label)
             else:
                 units.append("%s" % u)
         if as_list:

--- a/django/geno/tests/test_admin.py
+++ b/django/geno/tests/test_admin.py
@@ -10,7 +10,18 @@ import geno.tests.data as geno_testdata
 from geno import admin
 
 # from django.conf import settings
-from geno.models import Address, Child, ContentTemplate, Contract, GenericAttribute, Member
+from geno.models import (
+    Address,
+    Building,
+    Child,
+    ContentTemplate,
+    Contract,
+    GenericAttribute,
+    Member,
+    RentalUnit,
+    Share,
+    ShareType,
+)
 from geno.tests.base import MockDate
 from reservation.admin import ReservationAdmin
 from reservation.models import Reservation
@@ -616,3 +627,180 @@ class AddressAdminSearchTest(GenoAdminTestCase):
         # Multiple consecutive commas are stripped; all remaining words must match
         qs = self._search("test comment,,,with multiple commas")
         self.assertIn(self.adr_comment_multi, qs)
+
+
+class ShareAdminFilterTest(GenoAdminTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        stype = ShareType.objects.create(name="ShareFilterTest")
+
+        cls.building_A = Building.objects.create(name="A")
+        cls.building_B = Building.objects.create(name="B")
+        cls.building_C = Building.objects.create(name="C")
+        cls.building_inactive = Building.objects.create(name="inactive", active=False)
+
+        adr_unrelated = Address.objects.create(name="unrelated")
+        residentA = Address.objects.create(name="residentA")
+        residentB = Address.objects.create(name="residentB")
+        residentAB = Address.objects.create(name="residentAB")
+        residentABmulti = Address.objects.create(name="residentABmulti")
+
+        ruA = RentalUnit.objects.create(name="ruA", building=cls.building_A)
+        ruB = RentalUnit.objects.create(name="ruB", building=cls.building_B)
+
+        contract_A = Contract.objects.create(date=datetime.date.today())
+        contract_A.contractors.set([residentA])
+        contract_A.rental_units.set([ruA])
+        contract_A.save()
+
+        contract_B = Contract.objects.create(date=datetime.date.today())
+        contract_B.contractors.set([residentB])
+        contract_B.rental_units.set([ruB])
+        contract_B.save()
+
+        contract_AB_A = Contract.objects.create(date=datetime.date.today())
+        contract_AB_A.contractors.set([residentAB])
+        contract_AB_A.rental_units.set([ruA])
+        contract_AB_A.save()
+
+        contract_AB_B = Contract.objects.create(date=datetime.date.today())
+        contract_AB_B.contractors.set([residentAB])
+        contract_AB_B.rental_units.set([ruB])
+        contract_AB_B.save()
+
+        contract_A_and_B = Contract.objects.create(date=datetime.date.today())
+        contract_A_and_B.contractors.set([residentABmulti])
+        contract_A_and_B.rental_units.set([ruA, ruB])
+        contract_A_and_B.save()
+
+        cls.share_unrelated = Share.objects.create(
+            name=adr_unrelated, share_type=stype, payment_date=datetime.date.today(), value=1
+        )
+        cls.share_unrelated_linked_to_A_by_contract = Share.objects.create(
+            name=adr_unrelated,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+            attached_to_contract=contract_A,
+        )
+        cls.share_unrelated_linked_to_A_and_B_by_contract = Share.objects.create(
+            name=adr_unrelated,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+            attached_to_contract=contract_A_and_B,
+        )
+        cls.share_unrelated_linked_to_A_by_building = Share.objects.create(
+            name=adr_unrelated,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+            attached_to_building=cls.building_A,
+        )
+
+        cls.share_residentA = Share.objects.create(
+            name=residentA,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+        )
+        cls.share_residentA_linked_to_B_by_contract = Share.objects.create(
+            name=residentA,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+            attached_to_contract=contract_B,
+        )
+        cls.share_residentA_linked_to_B_by_building = Share.objects.create(
+            name=residentA,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+            attached_to_building=cls.building_B,
+        )
+
+        cls.share_residentAB = Share.objects.create(
+            name=residentAB,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+        )
+        cls.share_residentAB_linked_to_B_by_contract = Share.objects.create(
+            name=residentAB,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+            attached_to_contract=contract_B,
+        )
+        cls.share_residentAB_linked_to_B_by_building = Share.objects.create(
+            name=residentAB,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+            attached_to_building=cls.building_B,
+        )
+
+    def _create_filter(self, query_params=None):
+        factory = RequestFactory()
+        request = factory.get("/admin/geno/share/", query_params=query_params)
+        model_admin = admin.ShareAdmin(Share, django_admin.site)
+
+        share_filter = admin.ShareBuildingFilter(
+            request=request,
+            params=query_params or {},
+            model=Share,
+            model_admin=model_admin,
+        )
+        lookups = share_filter.lookups(request=request, model_admin=model_admin)
+        qs = share_filter.queryset(request, Share.objects.all())
+        return lookups, qs
+
+    def test_lookups(self):
+        lookups, _ = self._create_filter()
+        buildings = Building.objects.filter(active=True)
+        self.assertIsNotNone(lookups)
+        lookup_ids = [item[0] for item in lookups]
+        self.assertEqual(len(lookup_ids), buildings.count())
+        self.assertEqual(list(lookups)[0], (buildings[0].id, buildings[0].name))
+        self.assertNotIn(self.building_inactive.id, lookup_ids)
+
+    def test_buildingA(self):
+        _, qs = self._create_filter({"building_id": [self.building_A.id]})
+        self.assertEqual(
+            [
+                self.share_unrelated_linked_to_A_by_contract,
+                self.share_unrelated_linked_to_A_and_B_by_contract,
+                self.share_unrelated_linked_to_A_by_building,
+                self.share_residentA,
+                self.share_residentAB,
+            ],
+            list(qs),
+        )
+
+    def test_buildingB(self):
+        _, qs = self._create_filter({"building_id": [self.building_B.id]})
+        self.assertEqual(
+            [
+                self.share_unrelated_linked_to_A_and_B_by_contract,
+                self.share_residentA_linked_to_B_by_contract,
+                self.share_residentA_linked_to_B_by_building,
+                self.share_residentAB,
+                self.share_residentAB_linked_to_B_by_contract,
+                self.share_residentAB_linked_to_B_by_building,
+            ],
+            list(qs),
+        )
+
+    def test_buildingC(self):
+        _, qs = self._create_filter({"building_id": [self.building_C.id]})
+        self.assertEqual(qs.count(), 0)
+
+    def test_invalid_building_id(self):
+        _, qs = self._create_filter({"building_id": [-1]})
+        self.assertEqual(qs.count(), 0)
+
+    def test_no_filter(self):
+        _, qs = self._create_filter()
+        self.assertEqual(qs.count(), Share.get_active().count())

--- a/django/geno/tests/test_admin.py
+++ b/django/geno/tests/test_admin.py
@@ -648,12 +648,18 @@ class ShareAdminFilterTest(GenoAdminTestCase):
         residentABmulti = Address.objects.create(name="residentABmulti")
 
         ruA = RentalUnit.objects.create(name="ruA", building=cls.building_A)
+        ruA2 = RentalUnit.objects.create(name="ruA2", building=cls.building_A)
         ruB = RentalUnit.objects.create(name="ruB", building=cls.building_B)
 
         contract_A = Contract.objects.create(date=datetime.date.today())
         contract_A.contractors.set([residentA])
         contract_A.rental_units.set([ruA])
         contract_A.save()
+
+        contract_A_multi = Contract.objects.create(date=datetime.date.today())
+        contract_A_multi.contractors.set([residentA])
+        contract_A_multi.rental_units.set([ruA, ruA2])
+        contract_A_multi.save()
 
         contract_B = Contract.objects.create(date=datetime.date.today())
         contract_B.contractors.set([residentB])
@@ -691,6 +697,13 @@ class ShareAdminFilterTest(GenoAdminTestCase):
             payment_date=datetime.date.today(),
             value=1,
             attached_to_contract=contract_A_and_B,
+        )
+        cls.share_unrelated_linked_to_A_by_contract_multi = Share.objects.create(
+            name=residentA,
+            share_type=stype,
+            payment_date=datetime.date.today(),
+            value=1,
+            attached_to_contract=contract_A_multi,
         )
         cls.share_unrelated_linked_to_A_by_building = Share.objects.create(
             name=adr_unrelated,
@@ -768,10 +781,11 @@ class ShareAdminFilterTest(GenoAdminTestCase):
 
     def test_buildingA(self):
         _, qs = self._create_filter({"building_id": [self.building_A.id]})
-        self.assertEqual(
+        self.assertCountEqual(
             [
                 self.share_unrelated_linked_to_A_by_contract,
                 self.share_unrelated_linked_to_A_and_B_by_contract,
+                self.share_unrelated_linked_to_A_by_contract_multi,
                 self.share_unrelated_linked_to_A_by_building,
                 self.share_residentA,
                 self.share_residentAB,
@@ -781,7 +795,7 @@ class ShareAdminFilterTest(GenoAdminTestCase):
 
     def test_buildingB(self):
         _, qs = self._create_filter({"building_id": [self.building_B.id]})
-        self.assertEqual(
+        self.assertCountEqual(
             [
                 self.share_unrelated_linked_to_A_and_B_by_contract,
                 self.share_residentA_linked_to_B_by_contract,


### PR DESCRIPTION
- Add filter to get Shares related to a Building.
- Add calculated field related_contracts for Share.
- Change XLS export to use the admin fieldset by default and also include calculated fields.



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/cohiva/blob/v1.5.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced XLS exports with field labels, calculated fields, configurable field selections, and localized handling for invalid values.
  * Share details now display related rental units grouped by building.
* **Bug Fixes**
  * Prevented duplicate shares from appearing when multiple building relationships match a filter.
  * Improved rental unit grouping and labels in contract listings.
* **Tests**
  * Expanded coverage for multi-unit contracts and building-based share filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->